### PR TITLE
Can interface API

### DIFF
--- a/uavcan/Cargo.toml
+++ b/uavcan/Cargo.toml
@@ -22,5 +22,6 @@ std = []
 bit_field = "0.8.0"
 half = "1.0.0"
 uavcan-derive = {path = "../uavcan-derive"}
+embedded_types = "0.2.1"
 
 clippy = {version = "*", optional = true}

--- a/uavcan/Cargo.toml
+++ b/uavcan/Cargo.toml
@@ -22,6 +22,6 @@ std = []
 bit_field = "0.8.0"
 half = "1.0.0"
 uavcan-derive = {path = "../uavcan-derive"}
-embedded_types = "0.2.1"
+embedded_types = "0.3.0"
 
 clippy = {version = "*", optional = true}

--- a/uavcan/src/frame_assembler.rs
+++ b/uavcan/src/frame_assembler.rs
@@ -2,6 +2,7 @@ use bit_field::BitField;
 
 use transfer::{
     TransferFrame,
+    TransferID,
 };
 
 use {
@@ -40,7 +41,7 @@ pub struct FrameAssembler<F: Frame> {
     crc: u16,
     crc_calculated: u16,
     toggle: bool,
-    transfer_id: u8,    
+    transfer_id: TransferID,    
 }
 
 impl<F: Frame> FrameAssembler<F> {
@@ -52,7 +53,7 @@ impl<F: Frame> FrameAssembler<F> {
             crc: 0x00,
             crc_calculated: 0xffff,
             toggle: false,
-            transfer_id: 0x00,
+            transfer_id: 0x00.into(),
         }
     }
     

--- a/uavcan/src/frame_assembler.rs
+++ b/uavcan/src/frame_assembler.rs
@@ -1,8 +1,11 @@
 use bit_field::BitField;
 
+use transfer::{
+    TransferFrame,
+};
+
 use {
     Frame,
-    TransferFrame,
     Header,
 };
 

--- a/uavcan/src/frame_assembler.rs
+++ b/uavcan/src/frame_assembler.rs
@@ -2,6 +2,7 @@ use bit_field::BitField;
 
 use transfer::{
     TransferFrame,
+    TransferFrameID,
     TransferID,
 };
 
@@ -37,7 +38,7 @@ pub enum BuildError {
 pub struct FrameAssembler<F: Frame> {
     deserializer: Deserializer<F::Body>,
     started: bool,
-    id: u32,
+    id: TransferFrameID,
     crc: u16,
     crc_calculated: u16,
     toggle: bool,
@@ -49,7 +50,7 @@ impl<F: Frame> FrameAssembler<F> {
         Self{
             deserializer: Deserializer::new(),
             started: false,
-            id: 0x00,
+            id: 0x00.into(),
             crc: 0x00,
             crc_calculated: 0xffff,
             toggle: false,
@@ -119,7 +120,6 @@ mod tests {
     
     use tests::{
         CanFrame,
-        CanID,
     };
     
     use *;    
@@ -149,7 +149,7 @@ mod tests {
         uavcan_frame!(NodeStatusMessage, NodeStatusHeader, NodeStatus, 0);
             
         
-        let can_frame = CanFrame{id: CanID(NodeStatusHeader::new(0, 32).id()), dlc: 8, data: [1, 0, 0, 0, 0b10011100, 5, 0, TailByte::new(true, true, false, TransferID::from(0)).into()]};
+        let can_frame = CanFrame{id: TransferFrameID::from(NodeStatusHeader::new(0, 32).id()), dlc: 8, data: [1, 0, 0, 0, 0b10011100, 5, 0, TailByte::new(true, true, false, TransferID::from(0)).into()]};
         
         let mut message_builder = FrameAssembler::new();
         message_builder.add_transfer_frame(can_frame).unwrap();
@@ -196,25 +196,25 @@ mod tests {
         let mut message_builder = FrameAssembler::new();
         
         message_builder.add_transfer_frame(CanFrame{
-            id: CanID(LogMessageHeader::new(0, 32).id()),
+            id: TransferFrameID::from(LogMessageHeader::new(0, 32).id()),
             dlc: 8,
             data: [crc.get_bits(0..8) as u8, crc.get_bits(8..16) as u8, 0u8.set_bits(5..8, 0).set_bits(0..5, 11).get_bits(0..8), b't', b'e', b's', b't', TailByte::new(true, false, false, TransferID::from(0)).into()],
         }).unwrap();
         
         message_builder.add_transfer_frame(CanFrame{
-            id: CanID(LogMessageHeader::new(0, 32).id()),
+            id: TransferFrameID::from(LogMessageHeader::new(0, 32).id()),
             dlc: 8,
             data: [b' ', b's', b'o', b'u', b'r', b'c', b'e', TailByte::new(false, false, false, TransferID::from(0)).into()],
         }).unwrap();
         
         message_builder.add_transfer_frame(CanFrame{
-            id: CanID(LogMessageHeader::new(0, 32).id()),
+            id: TransferFrameID::from(LogMessageHeader::new(0, 32).id()),
             dlc: 8,
             data: [b't', b'e', b's', b't', b' ', b't', b'e', TailByte::new(false, false, false, TransferID::from(0)).into()],
         }).unwrap();
         
         message_builder.add_transfer_frame(CanFrame{
-            id: CanID(LogMessageHeader::new(0, 32).id()),
+            id: TransferFrameID::from(LogMessageHeader::new(0, 32).id()),
             dlc: 3,
             data: [b'x', b't', TailByte::new(false, true, true, TransferID::from(0)).into(), 0, 0, 0, 0, 0],
         }).unwrap();

--- a/uavcan/src/frame_assembler.rs
+++ b/uavcan/src/frame_assembler.rs
@@ -54,7 +54,7 @@ impl<F: Frame> FrameAssembler<F> {
             crc: 0x00,
             crc_calculated: 0xffff,
             toggle: false,
-            transfer_id: 0x00.into(),
+            transfer_id: TransferID::new(0x00),
         }
     }
     
@@ -149,7 +149,7 @@ mod tests {
         uavcan_frame!(NodeStatusMessage, NodeStatusHeader, NodeStatus, 0);
             
         
-        let can_frame = CanFrame{id: TransferFrameID::from(NodeStatusHeader::new(0, 32).id()), dlc: 8, data: [1, 0, 0, 0, 0b10011100, 5, 0, TailByte::new(true, true, false, TransferID::from(0)).into()]};
+        let can_frame = CanFrame{id: TransferFrameID::from(NodeStatusHeader::new(0, 32).id()), dlc: 8, data: [1, 0, 0, 0, 0b10011100, 5, 0, TailByte::new(true, true, false, TransferID::new(0)).into()]};
         
         let mut message_builder = FrameAssembler::new();
         message_builder.add_transfer_frame(can_frame).unwrap();
@@ -198,25 +198,25 @@ mod tests {
         message_builder.add_transfer_frame(CanFrame{
             id: TransferFrameID::from(LogMessageHeader::new(0, 32).id()),
             dlc: 8,
-            data: [crc.get_bits(0..8) as u8, crc.get_bits(8..16) as u8, 0u8.set_bits(5..8, 0).set_bits(0..5, 11).get_bits(0..8), b't', b'e', b's', b't', TailByte::new(true, false, false, TransferID::from(0)).into()],
+            data: [crc.get_bits(0..8) as u8, crc.get_bits(8..16) as u8, 0u8.set_bits(5..8, 0).set_bits(0..5, 11).get_bits(0..8), b't', b'e', b's', b't', TailByte::new(true, false, false, TransferID::new(0)).into()],
         }).unwrap();
         
         message_builder.add_transfer_frame(CanFrame{
             id: TransferFrameID::from(LogMessageHeader::new(0, 32).id()),
             dlc: 8,
-            data: [b' ', b's', b'o', b'u', b'r', b'c', b'e', TailByte::new(false, false, false, TransferID::from(0)).into()],
+            data: [b' ', b's', b'o', b'u', b'r', b'c', b'e', TailByte::new(false, false, false, TransferID::new(0)).into()],
         }).unwrap();
         
         message_builder.add_transfer_frame(CanFrame{
             id: TransferFrameID::from(LogMessageHeader::new(0, 32).id()),
             dlc: 8,
-            data: [b't', b'e', b's', b't', b' ', b't', b'e', TailByte::new(false, false, false, TransferID::from(0)).into()],
+            data: [b't', b'e', b's', b't', b' ', b't', b'e', TailByte::new(false, false, false, TransferID::new(0)).into()],
         }).unwrap();
         
         message_builder.add_transfer_frame(CanFrame{
             id: TransferFrameID::from(LogMessageHeader::new(0, 32).id()),
             dlc: 3,
-            data: [b'x', b't', TailByte::new(false, true, true, TransferID::from(0)).into(), 0, 0, 0, 0, 0],
+            data: [b'x', b't', TailByte::new(false, true, true, TransferID::new(0)).into(), 0, 0, 0, 0, 0],
         }).unwrap();
 
         assert_eq!(uavcan_frame.body.source.length().current_length, 11);

--- a/uavcan/src/frame_assembler.rs
+++ b/uavcan/src/frame_assembler.rs
@@ -50,7 +50,7 @@ impl<F: Frame> FrameAssembler<F> {
         Self{
             deserializer: Deserializer::new(),
             started: false,
-            id: 0x00.into(),
+            id: TransferFrameID::new(0x00),
             crc: 0x00,
             crc_calculated: 0xffff,
             toggle: false,

--- a/uavcan/src/frame_assembler.rs
+++ b/uavcan/src/frame_assembler.rs
@@ -63,13 +63,13 @@ impl<F: Frame> FrameAssembler<F> {
             if !frame.is_start_frame() {
                 return Err(AssemblerError::FirstFrameNotStartFrame);
             }
-            if frame.tail_byte().toggle {
+            if frame.tail_byte().toggle() {
                 return Err(AssemblerError::ToggleError);
             }
             self.toggle = false;
             self.crc.set_bits(0..8, frame.data()[0] as u16)
                 .set_bits(8..16, frame.data()[1] as u16); 
-            self.transfer_id = frame.tail_byte().transfer_id;
+            self.transfer_id = frame.tail_byte().transfer_id();
             self.id = frame.id();
             self.started = true;
         }

--- a/uavcan/src/frame_assembler.rs
+++ b/uavcan/src/frame_assembler.rs
@@ -125,6 +125,11 @@ mod tests {
     use *;    
     use types::*;
 
+    use transfer::{
+        TransferID,
+        TailByte,
+    };
+
     use frame_assembler::*;
     
     #[test]
@@ -144,7 +149,7 @@ mod tests {
         uavcan_frame!(NodeStatusMessage, NodeStatusHeader, NodeStatus, 0);
             
         
-        let can_frame = CanFrame{id: CanID(NodeStatusHeader::new(0, 32).id()), dlc: 8, data: [1, 0, 0, 0, 0b10011100, 5, 0, TailByte{start_of_transfer: true, end_of_transfer: true, toggle: false, transfer_id: 0}.into()]};
+        let can_frame = CanFrame{id: CanID(NodeStatusHeader::new(0, 32).id()), dlc: 8, data: [1, 0, 0, 0, 0b10011100, 5, 0, TailByte::new(true, true, false, TransferID::from(0)).into()]};
         
         let mut message_builder = FrameAssembler::new();
         message_builder.add_transfer_frame(can_frame).unwrap();
@@ -193,25 +198,25 @@ mod tests {
         message_builder.add_transfer_frame(CanFrame{
             id: CanID(LogMessageHeader::new(0, 32).id()),
             dlc: 8,
-            data: [crc.get_bits(0..8) as u8, crc.get_bits(8..16) as u8, 0u8.set_bits(5..8, 0).set_bits(0..5, 11).get_bits(0..8), b't', b'e', b's', b't', TailByte{start_of_transfer: true, end_of_transfer: false, toggle: false, transfer_id: 0}.into()],
+            data: [crc.get_bits(0..8) as u8, crc.get_bits(8..16) as u8, 0u8.set_bits(5..8, 0).set_bits(0..5, 11).get_bits(0..8), b't', b'e', b's', b't', TailByte::new(true, false, false, TransferID::from(0)).into()],
         }).unwrap();
         
         message_builder.add_transfer_frame(CanFrame{
             id: CanID(LogMessageHeader::new(0, 32).id()),
             dlc: 8,
-            data: [b' ', b's', b'o', b'u', b'r', b'c', b'e', TailByte{start_of_transfer: false, end_of_transfer: false, toggle: true, transfer_id: 0}.into()],
+            data: [b' ', b's', b'o', b'u', b'r', b'c', b'e', TailByte::new(false, false, false, TransferID::from(0)).into()],
         }).unwrap();
         
         message_builder.add_transfer_frame(CanFrame{
             id: CanID(LogMessageHeader::new(0, 32).id()),
             dlc: 8,
-            data: [b't', b'e', b's', b't', b' ', b't', b'e', TailByte{start_of_transfer: false, end_of_transfer: false, toggle: false, transfer_id: 0}.into()],
+            data: [b't', b'e', b's', b't', b' ', b't', b'e', TailByte::new(false, false, false, TransferID::from(0)).into()],
         }).unwrap();
         
         message_builder.add_transfer_frame(CanFrame{
             id: CanID(LogMessageHeader::new(0, 32).id()),
             dlc: 3,
-            data: [b'x', b't', TailByte{start_of_transfer: false, end_of_transfer: true, toggle: true, transfer_id: 0}.into(), 0, 0, 0, 0, 0],
+            data: [b'x', b't', TailByte::new(false, true, true, TransferID::from(0)).into(), 0, 0, 0, 0, 0],
         }).unwrap();
 
         assert_eq!(uavcan_frame.body.source.length().current_length, 11);

--- a/uavcan/src/frame_disassembler.rs
+++ b/uavcan/src/frame_disassembler.rs
@@ -114,7 +114,7 @@ mod tests {
         
         uavcan_frame!(NodeStatusMessage, NodeStatusHeader, NodeStatus, 0);
             
-        let can_frame = CanFrame{id: TransferFrameID::from(NodeStatusHeader::new(0, 32).id()), dlc: 8, data: [1, 0, 0, 0, 0b10011100, 5, 0, TailByte::new(true, true, false, TransferID::from(0)).into()]};
+        let can_frame = CanFrame{id: TransferFrameID::from(NodeStatusHeader::new(0, 32).id()), dlc: 8, data: [1, 0, 0, 0, 0b10011100, 5, 0, TailByte::new(true, true, false, TransferID::new(0)).into()]};
 
         let uavcan_frame = NodeStatusMessage{
             header: NodeStatusHeader::new(0, 32),
@@ -127,7 +127,7 @@ mod tests {
             },
         };
 
-        let mut frame_generator = FrameDisassembler::from_uavcan_frame(uavcan_frame, TransferID::from(0));
+        let mut frame_generator = FrameDisassembler::from_uavcan_frame(uavcan_frame, TransferID::new(0));
 
         assert_eq!(frame_generator.next_transfer_frame(), Some(can_frame));
         assert_eq!(frame_generator.next_transfer_frame::<CanFrame>(), None);
@@ -164,7 +164,7 @@ mod tests {
 
         assert_eq!(LogMessage::FLATTENED_FIELDS_NUMBER, 3);
         
-        let mut frame_generator = FrameDisassembler::from_uavcan_frame(uavcan_frame, TransferID::from(0));
+        let mut frame_generator = FrameDisassembler::from_uavcan_frame(uavcan_frame, TransferID::new(0));
 
         let crc = frame_generator.serializer.crc(0xd654a48e0c049d75);
 
@@ -174,7 +174,7 @@ mod tests {
             Some(CanFrame{
                 id: TransferFrameID::from(LogMessageHeader::new(0, 32).id()),
                 dlc: 8,
-                data: [crc.get_bits(0..8) as u8, crc.get_bits(8..16) as u8, 0u8.set_bits(0..5, 11).set_bits(5..8, 0).get_bits(0..8), b't', b'e', b's', b't', TailByte::new(true, false, false, TransferID::from(0)).into()],
+                data: [crc.get_bits(0..8) as u8, crc.get_bits(8..16) as u8, 0u8.set_bits(0..5, 11).set_bits(5..8, 0).get_bits(0..8), b't', b'e', b's', b't', TailByte::new(true, false, false, TransferID::new(0)).into()],
             })
         );
         
@@ -183,7 +183,7 @@ mod tests {
             Some(CanFrame{
                 id: TransferFrameID::from(LogMessageHeader::new(0, 32).id()),
                 dlc: 8,
-                data: [b' ', b's', b'o', b'u', b'r', b'c', b'e', TailByte::new(false, false, true, TransferID::from(0)).into()],
+                data: [b' ', b's', b'o', b'u', b'r', b'c', b'e', TailByte::new(false, false, true, TransferID::new(0)).into()],
             })
         );
         
@@ -192,7 +192,7 @@ mod tests {
             Some(CanFrame{
                 id: TransferFrameID::from(LogMessageHeader::new(0, 32).id()),
                 dlc: 8,
-                data: [b't', b'e', b's', b't', b' ', b't', b'e', TailByte::new(false, false, false, TransferID::from(0)).into()],
+                data: [b't', b'e', b's', b't', b' ', b't', b'e', TailByte::new(false, false, false, TransferID::new(0)).into()],
             })
         );
         
@@ -201,7 +201,7 @@ mod tests {
             Some(CanFrame{
                 id: TransferFrameID::from(LogMessageHeader::new(0, 32).id()),
                 dlc: 3,
-                data: [b'x', b't', TailByte::new(false, true, true, TransferID::from(0)).into(), 0, 0, 0, 0, 0],
+                data: [b'x', b't', TailByte::new(false, true, true, TransferID::new(0)).into(), 0, 0, 0, 0, 0],
             })
         );
 

--- a/uavcan/src/frame_disassembler.rs
+++ b/uavcan/src/frame_disassembler.rs
@@ -41,7 +41,7 @@ impl<F: Frame> FrameDisassembler<F> {
     pub fn finished(&self) -> bool { self.finished }
     
     pub fn next_transfer_frame<T: TransferFrame>(&mut self) -> Option<T> {
-        let max_data_length = T::max_data_length();
+        let max_data_length = T::MAX_DATA_LENGTH;
         let mut transport_frame = T::with_length(self.id, max_data_length);
         
         let first_of_multi_frame = !self.started && !self.serializer.single_frame_transfer();

--- a/uavcan/src/frame_disassembler.rs
+++ b/uavcan/src/frame_disassembler.rs
@@ -7,6 +7,7 @@ use {
 
 use transfer::{
     TransferFrame,
+    TransferFrameID,
     TailByte,
     TransferID,
 };
@@ -19,7 +20,7 @@ pub struct FrameDisassembler<F: Frame> {
     serializer: Serializer<F::Body>,
     started: bool,
     finished: bool,
-    id: u32,
+    id: TransferFrameID,
     toggle: bool,
     transfer_id: TransferID,
 }
@@ -89,7 +90,6 @@ mod tests {
     
     use tests::{
         CanFrame,
-        CanID,
     };
     
     use *;
@@ -113,7 +113,7 @@ mod tests {
         
         uavcan_frame!(NodeStatusMessage, NodeStatusHeader, NodeStatus, 0);
             
-        let can_frame = CanFrame{id: CanID(NodeStatusHeader::new(0, 32).id()), dlc: 8, data: [1, 0, 0, 0, 0b10011100, 5, 0, TailByte::new(true, true, false, TransferID::from(0)).into()]};
+        let can_frame = CanFrame{id: TransferFrameID::from(NodeStatusHeader::new(0, 32).id()), dlc: 8, data: [1, 0, 0, 0, 0b10011100, 5, 0, TailByte::new(true, true, false, TransferID::from(0)).into()]};
 
         let uavcan_frame = NodeStatusMessage{
             header: NodeStatusHeader::new(0, 32),
@@ -171,7 +171,7 @@ mod tests {
         assert_eq!(
             frame_generator.next_transfer_frame(),
             Some(CanFrame{
-                id: CanID(LogMessageHeader::new(0, 32).id()),
+                id: TransferFrameID::from(LogMessageHeader::new(0, 32).id()),
                 dlc: 8,
                 data: [crc.get_bits(0..8) as u8, crc.get_bits(8..16) as u8, 0u8.set_bits(0..5, 11).set_bits(5..8, 0).get_bits(0..8), b't', b'e', b's', b't', TailByte::new(true, false, false, TransferID::from(0)).into()],
             })
@@ -180,7 +180,7 @@ mod tests {
         assert_eq!(
             frame_generator.next_transfer_frame(),
             Some(CanFrame{
-                id: CanID(LogMessageHeader::new(0, 32).id()),
+                id: TransferFrameID::from(LogMessageHeader::new(0, 32).id()),
                 dlc: 8,
                 data: [b' ', b's', b'o', b'u', b'r', b'c', b'e', TailByte::new(false, false, true, TransferID::from(0)).into()],
             })
@@ -189,7 +189,7 @@ mod tests {
         assert_eq!(
             frame_generator.next_transfer_frame(),
             Some(CanFrame{
-                id: CanID(LogMessageHeader::new(0, 32).id()),
+                id: TransferFrameID::from(LogMessageHeader::new(0, 32).id()),
                 dlc: 8,
                 data: [b't', b'e', b's', b't', b' ', b't', b'e', TailByte::new(false, false, false, TransferID::from(0)).into()],
             })
@@ -198,7 +198,7 @@ mod tests {
         assert_eq!(
             frame_generator.next_transfer_frame(),
             Some(CanFrame{
-                id: CanID(LogMessageHeader::new(0, 32).id()),
+                id: TransferFrameID::from(LogMessageHeader::new(0, 32).id()),
                 dlc: 3,
                 data: [b'x', b't', TailByte::new(false, true, true, TransferID::from(0)).into(), 0, 0, 0, 0, 0],
             })

--- a/uavcan/src/frame_disassembler.rs
+++ b/uavcan/src/frame_disassembler.rs
@@ -113,7 +113,7 @@ mod tests {
         
         uavcan_frame!(NodeStatusMessage, NodeStatusHeader, NodeStatus, 0);
             
-        let can_frame = CanFrame{id: CanID(NodeStatusHeader::new(0, 32).id()), dlc: 8, data: [1, 0, 0, 0, 0b10011100, 5, 0, TailByte{start_of_transfer: true, end_of_transfer: true, toggle: false, transfer_id: 0}.into()]};
+        let can_frame = CanFrame{id: CanID(NodeStatusHeader::new(0, 32).id()), dlc: 8, data: [1, 0, 0, 0, 0b10011100, 5, 0, TailByte::new(true, true, false, TransferID::from(0)).into()]};
 
         let uavcan_frame = NodeStatusMessage{
             header: NodeStatusHeader::new(0, 32),
@@ -126,7 +126,7 @@ mod tests {
             },
         };
 
-        let mut frame_generator = FrameDisassembler::from_uavcan_frame(uavcan_frame, 0);
+        let mut frame_generator = FrameDisassembler::from_uavcan_frame(uavcan_frame, TransferID::from(0));
 
         assert_eq!(frame_generator.next_transfer_frame(), Some(can_frame));
         assert_eq!(frame_generator.next_transfer_frame::<CanFrame>(), None);
@@ -163,7 +163,7 @@ mod tests {
 
         assert_eq!(LogMessage::FLATTENED_FIELDS_NUMBER, 3);
         
-        let mut frame_generator = FrameDisassembler::from_uavcan_frame(uavcan_frame, 0);
+        let mut frame_generator = FrameDisassembler::from_uavcan_frame(uavcan_frame, TransferID::from(0));
 
         let crc = frame_generator.serializer.crc(0xd654a48e0c049d75);
 
@@ -173,7 +173,7 @@ mod tests {
             Some(CanFrame{
                 id: CanID(LogMessageHeader::new(0, 32).id()),
                 dlc: 8,
-                data: [crc.get_bits(0..8) as u8, crc.get_bits(8..16) as u8, 0u8.set_bits(0..5, 11).set_bits(5..8, 0).get_bits(0..8), b't', b'e', b's', b't', TailByte{start_of_transfer: true, end_of_transfer: false, toggle: false, transfer_id: 0}.into()],
+                data: [crc.get_bits(0..8) as u8, crc.get_bits(8..16) as u8, 0u8.set_bits(0..5, 11).set_bits(5..8, 0).get_bits(0..8), b't', b'e', b's', b't', TailByte::new(true, false, false, TransferID::from(0)).into()],
             })
         );
         
@@ -182,7 +182,7 @@ mod tests {
             Some(CanFrame{
                 id: CanID(LogMessageHeader::new(0, 32).id()),
                 dlc: 8,
-                data: [b' ', b's', b'o', b'u', b'r', b'c', b'e', TailByte{start_of_transfer: false, end_of_transfer: false, toggle: true, transfer_id: 0}.into()],
+                data: [b' ', b's', b'o', b'u', b'r', b'c', b'e', TailByte::new(false, false, true, TransferID::from(0)).into()],
             })
         );
         
@@ -191,7 +191,7 @@ mod tests {
             Some(CanFrame{
                 id: CanID(LogMessageHeader::new(0, 32).id()),
                 dlc: 8,
-                data: [b't', b'e', b's', b't', b' ', b't', b'e', TailByte{start_of_transfer: false, end_of_transfer: false, toggle: false, transfer_id: 0}.into()],
+                data: [b't', b'e', b's', b't', b' ', b't', b'e', TailByte::new(false, false, false, TransferID::from(0)).into()],
             })
         );
         
@@ -200,7 +200,7 @@ mod tests {
             Some(CanFrame{
                 id: CanID(LogMessageHeader::new(0, 32).id()),
                 dlc: 3,
-                data: [b'x', b't', TailByte{start_of_transfer: false, end_of_transfer: true, toggle: true, transfer_id: 0}.into(), 0, 0, 0, 0, 0],
+                data: [b'x', b't', TailByte::new(false, true, true, TransferID::from(0)).into(), 0, 0, 0, 0, 0],
             })
         );
 

--- a/uavcan/src/frame_disassembler.rs
+++ b/uavcan/src/frame_disassembler.rs
@@ -51,7 +51,7 @@ impl<F: Frame> FrameDisassembler<F> {
                 let mut buffer = SerializationBuffer::with_empty_buffer(&mut transport_frame.data_as_mut()[2..max_data_length-1]);
                 self.serializer.serialize(&mut buffer);
             }
-            transport_frame.data_as_mut()[max_data_length-1] = TailByte{start_of_transfer: !self.started, end_of_transfer: false, toggle: self.toggle, transfer_id: self.transfer_id}.into();
+            transport_frame.data_as_mut()[max_data_length-1] = TailByte::new(!self.started, false, self.toggle, self.transfer_id).into();
         } else {
             let (frame_length, end_of_transfer) = {
                 let mut buffer = SerializationBuffer::with_empty_buffer(&mut transport_frame.data_as_mut()[0..max_data_length-1]);
@@ -63,7 +63,7 @@ impl<F: Frame> FrameDisassembler<F> {
                 }
             };
             transport_frame.set_data_length(frame_length);
-            transport_frame.data_as_mut()[frame_length-1] = TailByte{start_of_transfer: !self.started, end_of_transfer: end_of_transfer, toggle: self.toggle, transfer_id: self.transfer_id}.into();
+            transport_frame.data_as_mut()[frame_length-1] = TailByte::new(!self.started, end_of_transfer, self.toggle, self.transfer_id).into();
         }
         
         self.started = true;

--- a/uavcan/src/frame_disassembler.rs
+++ b/uavcan/src/frame_disassembler.rs
@@ -42,7 +42,8 @@ impl<F: Frame> FrameDisassembler<F> {
     
     pub fn next_transfer_frame<T: TransferFrame>(&mut self) -> Option<T> {
         let max_data_length = T::MAX_DATA_LENGTH;
-        let mut transport_frame = T::with_length(self.id, max_data_length);
+        let mut transport_frame = T::new(self.id);
+        transport_frame.set_data_length(max_data_length);
         
         let first_of_multi_frame = !self.started && !self.serializer.single_frame_transfer();
 

--- a/uavcan/src/frame_disassembler.rs
+++ b/uavcan/src/frame_disassembler.rs
@@ -1,10 +1,14 @@
 use bit_field::BitField;
 
 use {
-    TailByte,
-    TransferFrame,
     Frame,
     Header,
+};
+
+use transfer::{
+    TransferFrame,
+    TailByte,
+    TransferID,
 };
 
 use serializer::*;
@@ -17,11 +21,11 @@ pub struct FrameDisassembler<F: Frame> {
     finished: bool,
     id: u32,
     toggle: bool,
-    transfer_id: u8,
+    transfer_id: TransferID,
 }
 
 impl<F: Frame> FrameDisassembler<F> {
-    pub fn from_uavcan_frame(frame: F, transfer_id: u8) -> Self {
+    pub fn from_uavcan_frame(frame: F, transfer_id: TransferID) -> Self {
         let (header, body) = frame.to_parts();
         Self{
             serializer: Serializer::from_structure(body),

--- a/uavcan/src/header_macros.rs
+++ b/uavcan/src/header_macros.rs
@@ -8,22 +8,22 @@ macro_rules! message_frame_header{
         }        
         
         impl uavcan::Header for $t {
-            fn id(&self) -> u32 {
+            fn id(&self) -> uavcan::transfer::TransferFrameID {
                 let mut id = 0;
                 id.set_bits(0..7, self.source_node as u32);
                 id.set_bit(7, false);
                 id.set_bits(8..24, <Self as uavcan::MessageFrameHeader>::TYPE_ID as u32);
                 id.set_bits(24..29, self.priority as u32);
-                return id;
+                uavcan::transfer::TransferFrameID::from(id)
             }
             
-            fn from_id(id: u32) -> Result<Self, ()> {
-                if id.get_bits(8..24) != <Self as uavcan::MessageFrameHeader>::TYPE_ID as u32 {
+            fn from_id(id: uavcan::transfer::TransferFrameID) -> Result<Self, ()> {
+                if u32::from(id).get_bits(8..24) != <Self as uavcan::MessageFrameHeader>::TYPE_ID as u32 {
                     Err(())
                 } else {
                     Ok(Self{
-                        priority: id.get_bits(24..29) as u8,
-                        source_node: id.get_bits(0..7) as u8,
+                        priority: u32::from(id).get_bits(24..29) as u8,
+                        source_node: u32::from(id).get_bits(0..7) as u8,
                     })
                 }
             }
@@ -58,23 +58,23 @@ macro_rules! anonymous_frame_header{
         }
 
         impl uavcan::Header for $t {
-            fn id(&self) -> u32 {
+            fn id(&self) -> uavcan::transfer::TransferFrameID {
                 let mut id = 0;
                 id.set_bits(0..7, 0);
                 id.set_bit(7, false);
                 id.set_bits(8..10, <Self as uavcan::AnonymousFrameHeader>::TYPE_ID as u32);
                 id.set_bits(10..24, self.discriminator as u32);
                 id.set_bits(24..29, self.priority as u32);
-                return id;
+                uavcan::transfer::TransferFrameID::from(id)
             }
    
-            fn from_id(id: u32) -> Result<Self, ()> {
-                if id.get_bits(8..24) != <Self as uavcan::AnonymousFrameHeader>::TYPE_ID as u32 {
+            fn from_id(id: uavcan::transfer::TransferFrameID) -> Result<Self, ()> {
+                if u32::from(id).get_bits(8..24) != <Self as uavcan::AnonymousFrameHeader>::TYPE_ID as u32 {
                     Err(())
                 } else {
                     Ok(Self{
-                        priority: id.get_bits(24..29) as u8,
-                        discriminator: id.get_bits(10..24) as u16,
+                        priority: u32::from(id).get_bits(24..29) as u8,
+                        discriminator: u32::from(id).get_bits(10..24) as u16,
                     })
                 }
             }
@@ -113,23 +113,24 @@ macro_rules! service_frame_header{
         }
 
         impl uavcan::Header for $t {
-            fn id(&self) -> u32 {
+            fn id(&self) -> uavcan::transfer::TransferFrameID {
                 let mut id = 0;
                 id.set_bits(0..7, self.source_node as u32);
                 id.set_bit(7, false);
                 id.set_bits(8..24, <Self as uavcan::ServiceFrameHeader>::TYPE_ID as u32);
                 id.set_bits(24..29, self.priority as u32);
-                return id;
+                uavcan::transfer::TransferFrameID::from(id)
             }
-            fn from_id(id: u32) -> Result<Self, ()> {
-                if id.get_bits(8..24) != <Self as uavcan::ServiceFrameHeader>::TYPE_ID as u32 {
+            
+            fn from_id(id: uavcan::transfer::TransferFrameID) -> Result<Self, ()> {
+                if u32::from(id).get_bits(8..24) != <Self as uavcan::ServiceFrameHeader>::TYPE_ID as u32 {
                     Err(())
                 } else {
                     Ok(Self{
-                        priority: id.get_bits(24..29) as u8,
-                        request_not_response: id.get_bit(15),
-                        destination_node: id.get_bits(8..14) as u8,
-                        source_node: id.get_bits(0..7) as u8,
+                        priority: u32::from(id).get_bits(24..29) as u8,
+                        request_not_response: u32::from(id).get_bit(15),
+                        destination_node: u32::from(id).get_bits(8..14) as u8,
+                        source_node: u32::from(id).get_bits(0..7) as u8,
                     })
                 }
             }

--- a/uavcan/src/header_macros.rs
+++ b/uavcan/src/header_macros.rs
@@ -14,7 +14,7 @@ macro_rules! message_frame_header{
                 id.set_bit(7, false);
                 id.set_bits(8..24, <Self as uavcan::MessageFrameHeader>::TYPE_ID as u32);
                 id.set_bits(24..29, self.priority as u32);
-                uavcan::transfer::TransferFrameID::from(id)
+                uavcan::transfer::TransferFrameID::new(id)
             }
             
             fn from_id(id: uavcan::transfer::TransferFrameID) -> Result<Self, ()> {
@@ -65,7 +65,7 @@ macro_rules! anonymous_frame_header{
                 id.set_bits(8..10, <Self as uavcan::AnonymousFrameHeader>::TYPE_ID as u32);
                 id.set_bits(10..24, self.discriminator as u32);
                 id.set_bits(24..29, self.priority as u32);
-                uavcan::transfer::TransferFrameID::from(id)
+                uavcan::transfer::TransferFrameID::new(id)
             }
    
             fn from_id(id: uavcan::transfer::TransferFrameID) -> Result<Self, ()> {
@@ -119,7 +119,7 @@ macro_rules! service_frame_header{
                 id.set_bit(7, false);
                 id.set_bits(8..24, <Self as uavcan::ServiceFrameHeader>::TYPE_ID as u32);
                 id.set_bits(24..29, self.priority as u32);
-                uavcan::transfer::TransferFrameID::from(id)
+                uavcan::transfer::TransferFrameID::new(id)
             }
             
             fn from_id(id: uavcan::transfer::TransferFrameID) -> Result<Self, ()> {

--- a/uavcan/src/lib.rs
+++ b/uavcan/src/lib.rs
@@ -15,6 +15,7 @@
 extern crate uavcan_derive;
 
 extern crate bit_field;
+extern crate embedded_types;
 extern crate half;
 
 mod lib {

--- a/uavcan/src/lib.rs
+++ b/uavcan/src/lib.rs
@@ -47,11 +47,6 @@ use bit_field::BitField;
 
 use lib::core::ops::Range;
 
-use transfer::{
-    TransferFrame,
-    TailByte,
-};
-
 pub use serializer::{
     SerializationResult,
     SerializationBuffer,        

--- a/uavcan/src/lib.rs
+++ b/uavcan/src/lib.rs
@@ -205,7 +205,7 @@ mod tests {
         pub data: [u8; 8],
     }
 
-    impl TransferFrame for CanFrame {
+    impl transfer::TransferFrame for CanFrame {
         fn with_data(id: u32, data: &[u8]) -> CanFrame {
             let mut can_data = [0; 8];
             can_data[0..data.len()].clone_from_slice(data);

--- a/uavcan/src/lib.rs
+++ b/uavcan/src/lib.rs
@@ -207,14 +207,8 @@ mod tests {
     impl transfer::TransferFrame for CanFrame {
         const MAX_DATA_LENGTH: usize = 8;
         
-        fn with_data(id: TransferFrameID, data: &[u8]) -> CanFrame {
-            let mut can_data = [0; 8];
-            can_data[0..data.len()].clone_from_slice(data);
-            CanFrame{id: id, dlc: data.len(), data: can_data}
-        }
-
-        fn with_length(id: TransferFrameID, length: usize) -> CanFrame {
-            CanFrame{id: id, dlc: length, data: [0; 8]}
+        fn new(id: TransferFrameID) -> CanFrame {
+            CanFrame{id: id, dlc: 0, data: [0; 8]}
         }
         
         fn set_data_length(&mut self, length: usize) {

--- a/uavcan/src/lib.rs
+++ b/uavcan/src/lib.rs
@@ -34,6 +34,7 @@ mod uavcan {
 pub use uavcan_derive::*;
 
 #[macro_use]
+pub mod transfer;
 mod header_macros;
 pub mod types;
 mod crc;
@@ -44,8 +45,12 @@ pub mod frame_disassembler;
 
 use bit_field::BitField;
 
-use lib::core::convert::{From};
 use lib::core::ops::Range;
+
+use transfer::{
+    TransferFrame,
+    TailByte,
+};
 
 pub use serializer::{
     SerializationResult,
@@ -56,60 +61,6 @@ pub use deserializer::{
     DeserializationResult,
     DeserializationBuffer,
 };
-
-
-/// The TransportFrame is uavcan cores main interface to the outside world
-///
-/// This will in >99% of situations be a CAN2.0B frame
-/// But in theory both CAN-FD and other protocols which gives
-/// similar guarantees as CAN can also be used
-pub trait TransferFrame {
-    fn tail_byte(&self) -> TailByte {
-        TailByte::from(*self.data().last().unwrap())
-    }
-    fn is_start_frame(&self) -> bool {
-        self.tail_byte().start_of_transfer
-    }
-    fn is_end_frame(&self) -> bool {
-        self.tail_byte().end_of_transfer
-    }
-    fn is_single_frame(&self) -> bool {
-        self.is_end_frame() && self.is_start_frame()
-    }
-
-    /// with_data(id: u32, data: &[u]) -> TransportFrame creates a TransportFrame
-    /// with an 28 bits ID and data between 0 and the return value ofget_max_data_length()
-    fn with_data(id: u32,  data: &[u8]) -> Self;
-    fn with_length(id: u32, length: usize) -> Self;
-    fn set_data_length(&mut self, length: usize);
-    fn max_data_length() -> usize;
-    fn data(&self) -> &[u8];
-    fn data_as_mut(&mut self) -> &mut[u8];
-    fn id(&self) -> u32;
-}
-
-pub struct TailByte {
-    start_of_transfer: bool,
-    end_of_transfer: bool,
-    toggle: bool,
-    transfer_id: u8,
-}
-
-impl From<TailByte> for u8 {
-    fn from(tb: TailByte) -> u8 {
-        ((tb.start_of_transfer as u8) << 7) | ((tb.end_of_transfer as u8) << 6) | ((tb.toggle as u8) << 5) | (tb.transfer_id&0x1f)
-    }
-}
-
-impl From<u8> for TailByte {
-    fn from(u: u8) -> TailByte {
-        TailByte{start_of_transfer: (u&(1<<7)) != 0, end_of_transfer: (u&(1<<6)) != 0, toggle: (u&(1<<5)) != 0, transfer_id: u&0x1f}
-    }
-}
-
-
-
-
 
 
 pub trait Header {

--- a/uavcan/src/lib.rs
+++ b/uavcan/src/lib.rs
@@ -33,8 +33,8 @@ mod uavcan {
 
 pub use uavcan_derive::*;
 
-#[macro_use]
 pub mod transfer;
+#[macro_use]
 mod header_macros;
 pub mod types;
 mod crc;

--- a/uavcan/src/lib.rs
+++ b/uavcan/src/lib.rs
@@ -205,6 +205,8 @@ mod tests {
     }
 
     impl transfer::TransferFrame for CanFrame {
+        const MAX_DATA_LENGTH: usize = 8;
+        
         fn with_data(id: TransferFrameID, data: &[u8]) -> CanFrame {
             let mut can_data = [0; 8];
             can_data[0..data.len()].clone_from_slice(data);
@@ -215,10 +217,6 @@ mod tests {
             CanFrame{id: id, dlc: length, data: [0; 8]}
         }
         
-        fn max_data_length() -> usize {
-            8
-        }
-
         fn set_data_length(&mut self, length: usize) {
             assert!(length <= 8);
             self.dlc = length;

--- a/uavcan/src/lib.rs
+++ b/uavcan/src/lib.rs
@@ -47,6 +47,8 @@ use bit_field::BitField;
 
 use lib::core::ops::Range;
 
+use transfer::TransferFrameID;
+
 pub use serializer::{
     SerializationResult,
     SerializationBuffer,        
@@ -59,9 +61,9 @@ pub use deserializer::{
 
 
 pub trait Header {
-    fn from_id(u32) -> Result<Self, ()> where Self: Sized;
+    fn from_id(TransferFrameID) -> Result<Self, ()> where Self: Sized;
     
-    fn id(&self) -> u32;
+    fn id(&self) -> TransferFrameID;
     fn set_priority(&mut self, priority: u8);
     fn get_priority(&self) -> u8;
 }
@@ -192,28 +194,25 @@ pub trait Frame {
 mod tests {
 
     use *;
-    
+
     // Implementing some types common for several tests
     
     #[derive(Debug, PartialEq)]
-    pub struct CanID(pub u32);
-
-    #[derive(Debug, PartialEq)]
     pub struct CanFrame {
-        pub id: CanID,
+        pub id: TransferFrameID,
         pub dlc: usize,
         pub data: [u8; 8],
     }
 
     impl transfer::TransferFrame for CanFrame {
-        fn with_data(id: u32, data: &[u8]) -> CanFrame {
+        fn with_data(id: TransferFrameID, data: &[u8]) -> CanFrame {
             let mut can_data = [0; 8];
             can_data[0..data.len()].clone_from_slice(data);
-            CanFrame{id: CanID(id), dlc: data.len(), data: can_data}
+            CanFrame{id: id, dlc: data.len(), data: can_data}
         }
 
-        fn with_length(id: u32, length: usize) -> CanFrame {
-            CanFrame{id: CanID(id), dlc: length, data: [0; 8]}
+        fn with_length(id: TransferFrameID, length: usize) -> CanFrame {
+            CanFrame{id: id, dlc: length, data: [0; 8]}
         }
         
         fn max_data_length() -> usize {
@@ -233,10 +232,8 @@ mod tests {
             &mut self.data[0..self.dlc]
         }
         
-        fn id(&self) -> u32 {
-            match self.id {
-                CanID(x) => x,
-            }
+        fn id(&self) -> TransferFrameID {
+            self.id 
         }
     }
 

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -180,6 +180,7 @@ impl From<u8> for TransferID {
 }
 
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct TailByte(u8);
 
 impl TailByte {

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -128,6 +128,11 @@ impl FullTransferID {
 pub struct TransferFrameID(u32);
 
 impl TransferFrameID {
+    pub fn new(value: u32) -> TransferFrameID {
+        assert_eq!(value & !0x1fff_ffff, 0);
+        TransferFrameID(value)
+    }
+
     pub fn mask(self, mask: Self) -> Self {
         let TransferFrameID(mut value) = self;
         value = value & u32::from(mask);
@@ -139,13 +144,6 @@ impl From<TransferFrameID> for u32 {
     fn from(id: TransferFrameID) -> u32 {
         let TransferFrameID(value) = id;
         value
-    }
-}
-
-impl From<u32> for TransferFrameID {
-    fn from(value: u32) -> TransferFrameID {
-        assert_eq!(value & !0x1fff_ffff, 0);
-        TransferFrameID(value)
     }
 }
 
@@ -235,7 +233,7 @@ impl From<TransferFrameID> for embedded_types::can::ID {
 
 impl From<embedded_types::can::ExtendedID> for TransferFrameID {
     fn from(id: embedded_types::can::ExtendedID) -> Self {
-        TransferFrameID::from(u32::from(id))
+        TransferFrameID::new(u32::from(id))
     }
 }
 

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -35,7 +35,11 @@ pub trait TransferInterface<'a>
     ///
     /// 1. Matches `identifier` when masked.
     ///
-    /// 2. There exists an end_frame (`TransferFrame::is_end_frame(&self)`is asserted) with this `FullTransferID` in the receive buffer
+    /// 2. There exists an end_frame (`TransferFrame::is_end_frame(&self)`is asserted) with this `FullTransferID` in the receive buffer.
+    ///
+    /// 3. If multiple completed transfers matches, the one with highest priority will be returned (based on arbitration off `TransferFrameID`).
+    ///
+    /// 4. If multiple transfers with the same `TransferFrameID` matches, the `FullTransferID` of the one received first will be returned.
     fn completed_receive(&self, identifier: FullTransferID, mask: FullTransferID) -> Option<FullTransferID>;
 }
 

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -82,8 +82,11 @@ pub trait TransferFrame {
     fn set_data_length(&mut self, length: usize);
     
     /// Returns the tail byte of the TransferFrame assuming the current length
+    ///
+    /// ## Panics
+    /// panics if `self.data().len() == 0` as no tail_byte exists
     fn tail_byte(&self) -> TailByte {
-        TailByte::from(*self.data().last().unwrap())
+        TailByte::from(*self.data().last().expect("Can't return tail byte of frame with 0 data bytes"))
     }
 
     /// Checks the tail byte if this frame is a start frame and return the result
@@ -102,6 +105,9 @@ pub trait TransferFrame {
     }
 
     /// Returns the full ID of the frame (both Frame ID and transfer ID)
+    ///
+    /// ## Panics
+    /// panics if `self.data().len() == 0` as no tail_byte exists
     fn full_id(&self) -> FullTransferID {
         FullTransferID{frame_id: self.id(), transfer_id: self.tail_byte().transfer_id()} 
     }

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -8,10 +8,10 @@ pub trait TransferFrame {
         TailByte::from(*self.data().last().unwrap())
     }
     fn is_start_frame(&self) -> bool {
-        self.tail_byte().start_of_transfer
+        self.tail_byte().start_of_transfer()
     }
     fn is_end_frame(&self) -> bool {
-        self.tail_byte().end_of_transfer
+        self.tail_byte().end_of_transfer()
     }
     fn is_single_frame(&self) -> bool {
         self.is_end_frame() && self.is_start_frame()
@@ -28,22 +28,35 @@ pub trait TransferFrame {
     fn id(&self) -> u32;
 }
 
-pub struct TailByte {
-    start_of_transfer: bool,
-    end_of_transfer: bool,
-    toggle: bool,
-    transfer_id: u8,
+pub struct TailByte(u8);
+
+impl TailByte {
+    pub fn new(start_of_transfer: bool, end_of_transfer: bool, toggle: bool, transfer_id: u8) -> Self {
+        assert_eq!(transfer_id & 0x1f, 0x00);
+        TailByte( ((start_of_transfer as u8)<<7) | ((end_of_transfer as u8)<<6) | ((toggle as u8)<<5) | (transfer_id<<0) )
+    }
+    
+    pub fn start_of_transfer(&self) -> bool {
+        let TailByte(value) = *self;
+        value & (1<<7) != 0
+    }
+
+    pub fn end_of_transfer(&self) -> bool {unimplemented!()}
+    pub fn toggle(&self) -> bool {unimplemented!()}
+    pub fn transfer_id(&self) -> u8 {unimplemented!()}
 }
+
 
 impl From<TailByte> for u8 {
     fn from(tb: TailByte) -> u8 {
-        ((tb.start_of_transfer as u8) << 7) | ((tb.end_of_transfer as u8) << 6) | ((tb.toggle as u8) << 5) | (tb.transfer_id&0x1f)
+        let TailByte(value) = tb;
+        value
     }
 }
 
 impl From<u8> for TailByte {
-    fn from(u: u8) -> TailByte {
-        TailByte{start_of_transfer: (u&(1<<7)) != 0, end_of_transfer: (u&(1<<6)) != 0, toggle: (u&(1<<5)) != 0, transfer_id: u&0x1f}
+    fn from(value: u8) -> TailByte {
+        TailByte(value)
     }
 }
 

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -103,6 +103,11 @@ pub trait TransferFrame {
         self.is_end_frame() && self.is_start_frame()
     }
 
+    /// Returns the full ID of the frame (both Frame ID and transfer ID)
+    fn full_id(&self) -> FullTransferID {
+        FullTransferID{frame_id: self.id(), transfer_id: self.tail_byte().transfer_id()} 
+    }
+
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -46,6 +46,16 @@ pub struct FullTransferID {
     pub transfer_id: TransferID,
 }
 
+impl FullTransferID {
+    pub fn mask(self, mask: Self) -> Self {
+        FullTransferID{
+            frame_id: self.frame_id.mask(mask.frame_id),
+            transfer_id: self.transfer_id.mask(mask.transfer_id),
+        }
+    }
+}
+
+
 /// `TransferFrame` is a CAN like frame that can be sent over a network
 ///
 /// For a frame to work it need to have a 28 bit ID, and a payload of
@@ -116,6 +126,14 @@ pub trait TransferFrame {
 #[cfg_attr(not(feature="std"), derive(Clone, Copy, Debug, Eq, PartialEq))]
 pub struct TransferFrameID(u32);
 
+impl TransferFrameID {
+    pub fn mask(self, mask: Self) -> Self {
+        let TransferFrameID(mut value) = self;
+        value = value & u32::from(mask);
+        TransferFrameID(value)        
+    }
+}
+
 impl From<TransferFrameID> for u32 {
     fn from(id: TransferFrameID) -> u32 {
         let TransferFrameID(value) = id;
@@ -177,6 +195,14 @@ impl From<u8> for TailByte {
 #[cfg_attr(feature="std", derive(Clone, Copy, Debug, Eq, PartialEq, Hash))]
 #[cfg_attr(not(feature="std"), derive(Clone, Copy, Debug, Eq, PartialEq))]
 pub struct TransferID(u8);
+
+impl TransferID {
+    pub fn mask(self, mask: Self) -> Self {
+        let TransferID(mut value) = self;
+        value = value & u8::from(mask);
+        TransferID(value)        
+    }
+}
 
 impl From<TransferID> for u8 {
     fn from(tid: TransferID) -> u8 {

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -9,7 +9,7 @@ pub enum TransmitError {
     BufferFull,
 }
 
-/// TransferInterface is an interface to a hardware unit which can communicate over a CAN like transfer protocol
+/// `TransferInterface` is an interface to a hardware unit which can communicate over a CAN like transfer protocol
 ///
 /// It's associated with a `TransferFrame` and must be able to receive and transmit this type of frames.
 /// The interface must also do ordering of incoming frames after priority defined by the transfer frame ID to avoid priority inversion,
@@ -44,7 +44,7 @@ pub struct FullTransferID {
     pub transfer_id: TransferID,
 }
 
-/// The TransferFrame is a CAN like frame that can be sent over a network
+/// `TransferFrame` is a CAN like frame that can be sent over a network
 ///
 /// For a frame to work it need to have a 28 bit ID, and a payload of
 /// at least 4 bytes. Guarantee that frames are delivered in order
@@ -116,7 +116,7 @@ impl From<TransferFrameID> for u32 {
 
 impl From<u32> for TransferFrameID {
     fn from(value: u32) -> TransferFrameID {
-        assert_eq!(value & !0x1fffffff, 0);
+        assert_eq!(value & !0x1fff_ffff, 0);
         TransferFrameID(value)
     }
 }

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -22,14 +22,32 @@ pub trait TransferFrame {
 
     /// with_data(id: u32, data: &[u]) -> TransportFrame creates a TransportFrame
     /// with an 28 bits ID and data between 0 and the return value ofget_max_data_length()
-    fn with_data(id: u32,  data: &[u8]) -> Self;
-    fn with_length(id: u32, length: usize) -> Self;
+    fn with_data(id: TransferFrameID,  data: &[u8]) -> Self;
+    fn with_length(id: TransferFrameID, length: usize) -> Self;
     fn set_data_length(&mut self, length: usize);
     fn max_data_length() -> usize;
     fn data(&self) -> &[u8];
     fn data_as_mut(&mut self) -> &mut[u8];
-    fn id(&self) -> u32;
+    fn id(&self) -> TransferFrameID;
 }
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TransferFrameID(u32);
+
+impl From<TransferFrameID> for u32 {
+    fn from(id: TransferFrameID) -> u32 {
+        let TransferFrameID(value) = id;
+        value
+    }
+}
+
+impl From<u32> for TransferFrameID {
+    fn from(value: u32) -> TransferFrameID {
+        assert_eq!(value & !0x1fffffff, 0);
+        TransferFrameID(value)
+    }
+}
+
 
 pub struct TailByte(u8);
 

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -7,10 +7,7 @@ use lib::core::ops::Deref;
 
 use embedded_types;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum TransmitError {
-    BufferFull,
-}
+pub use embedded_types::io::Error as IOError;
 
 /// `TransferInterface` is an interface to a hardware unit which can communicate over a CAN like transfer protocol
 ///
@@ -33,7 +30,7 @@ pub trait TransferInterface<'a>
     ///
     /// To avoid priority inversion the new frame needs to be prioritized inside the interface as it would on the bus.
     /// When reprioritizing the `TransferInterface` must for equal ID frames respect the order they were attempted transmitted in.
-    fn transmit(&self, frame: &Self::Frame) -> Result<(), TransmitError>;
+    fn transmit(&self, frame: &Self::Frame) -> Result<(), IOError>;
 
     /// Receive a transfer frame matching `identifier`.
     ///

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -1,6 +1,12 @@
 use lib::core::convert::{From};
 
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct FullTransferID {
+    pub frame_id: TransferFrameID,
+    pub transfer_id: TransferID,
+}
+
 /// The TransportFrame is uavcan cores main interface to the outside world
 ///
 /// This will in >99% of situations be a CAN2.0B frame

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -31,7 +31,7 @@ pub trait TransferInterface {
     /// Receive the oldest transfer frame optionally matching an identifier.
     ///
     /// if no identifier is specified, return the oldest frame matching any identifier.
-    fn receive(&self, identifier: Option<&FullTransferID>) -> Option<Self::Frame>;
+    fn receive(&self, identifier: &FullTransferID) -> Option<Self::Frame>;
 
     /// Returns a slice with transfer IDs to all transfer frames where `frame.is_end_frame()` is asserted
     ///

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -5,6 +5,7 @@
 use lib::core::convert::{From};
 use lib::core::ops::Index;
 
+use embedded_types;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TransmitError {
@@ -223,3 +224,35 @@ impl From<u8> for TailByte {
     }
 }
 
+
+
+
+
+
+impl From<TransferFrameID> for embedded_types::can::ExtendedID {
+    fn from(id: TransferFrameID) -> Self {
+        embedded_types::can::ExtendedID::new(u32::from(id))
+    }
+}
+
+impl From<TransferFrameID> for embedded_types::can::ID {
+    fn from(id: TransferFrameID) -> Self {
+        embedded_types::can::ID::ExtendedID(embedded_types::can::ExtendedID::from(id))
+    }
+}
+
+impl From<embedded_types::can::ExtendedID> for TransferFrameID {
+    fn from(id: embedded_types::can::ExtendedID) -> Self {
+        TransferFrameID::from(u32::from(id))
+    }
+}
+
+impl TransferFrame for embedded_types::can::ExtendedDataFrame {
+    const MAX_DATA_LENGTH: usize = 8;
+
+    fn new(id: TransferFrameID) -> Self { embedded_types::can::ExtendedDataFrame::new(id.into()) }
+    fn set_data_length(&mut self, length: usize) {self.set_data_length(length);}
+    fn data(&self) -> &[u8] {&self.data()}
+    fn data_as_mut(&mut self) -> &mut [u8] {self.data_as_mut()}
+    fn id(&self) -> TransferFrameID {self.id().clone().into()}
+}

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -21,11 +21,6 @@ pub trait TransferInterface<'a>
     /// The TransferFrame associated with this interface.
     type Frame: TransferFrame;
 
-    /// A container for `FullTransferID`s that is indexable and iterable.
-    ///
-    /// Suitable types are `&[FullTransferID]` or `Box<[FullTransferID]>` (which can be constructed from `Vec<FullTransferID>` by calling `into_boxed_slice`
-    type IDContainer: Deref<Target=[FullTransferID]>;
-
     /// Put a `TransferFrame` in the transfer buffer (or transmit it on the bus) or report an error.
     ///
     /// To avoid priority inversion the new frame needs to be prioritized inside the interface as it would on the bus.
@@ -37,12 +32,12 @@ pub trait TransferInterface<'a>
     /// It's important that `receive` returns frames in the same order they were received from the bus.
     fn receive(&self, identifier: &FullTransferID) -> Option<Self::Frame>;
 
-    /// Returns an indexable type containing all `FullTransferID`s that:
+    /// Returns a FullTransferID that satisfies the following:
     ///
     /// 1. Matches `identifier` when masked.
     ///
     /// 2. There exists an end_frame (`TransferFrame::is_end_frame(&self)`is asserted) with this `FullTransferID` in the receive buffer
-    fn completed_receives(&self, identifier: FullTransferID, mask: FullTransferID) -> Self::IDContainer;
+    fn completed_receive(&self, identifier: FullTransferID, mask: FullTransferID) -> Option<FullTransferID>;
 }
 
 /// `TransferFrame` is a CAN like frame that can be sent over a network

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -1,3 +1,6 @@
+use lib::core::convert::{From};
+
+
 /// The TransportFrame is uavcan cores main interface to the outside world
 ///
 /// This will in >99% of situations be a CAN2.0B frame

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -3,7 +3,6 @@
 //! The only transfer protocol that is currently supported by the uavcan protocol is CAN2.0B.
 
 use lib::core::convert::{From};
-use lib::core::ops::Deref;
 
 use embedded_types;
 

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -39,7 +39,8 @@ pub trait TransferInterface {
     fn received_completely(&self) -> &[FullTransferID];
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature="std", derive(Clone, Copy, Debug, Eq, PartialEq, Hash))]
+#[cfg_attr(not(feature="std"), derive(Clone, Copy, Debug, Eq, PartialEq))]
 pub struct FullTransferID {
     pub frame_id: TransferFrameID,
     pub transfer_id: TransferID,
@@ -110,7 +111,9 @@ pub trait TransferFrame {
 
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+
+#[cfg_attr(feature="std", derive(Clone, Copy, Debug, Eq, PartialEq, Hash))]
+#[cfg_attr(not(feature="std"), derive(Clone, Copy, Debug, Eq, PartialEq))]
 pub struct TransferFrameID(u32);
 
 impl From<TransferFrameID> for u32 {
@@ -170,7 +173,9 @@ impl From<u8> for TailByte {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+
+#[cfg_attr(feature="std", derive(Clone, Copy, Debug, Eq, PartialEq, Hash))]
+#[cfg_attr(not(feature="std"), derive(Clone, Copy, Debug, Eq, PartialEq))]
 pub struct TransferID(u8);
 
 impl From<TransferID> for u8 {

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -48,8 +48,7 @@ pub trait TransferInterface
     fn completed_receives(&self, identifier: FullTransferID, mask: FullTransferID) -> Self::IDContainer;
 }
 
-#[cfg_attr(feature="std", derive(Clone, Copy, Debug, Eq, PartialEq, Hash))]
-#[cfg_attr(not(feature="std"), derive(Clone, Copy, Debug, Eq, PartialEq))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct FullTransferID {
     pub frame_id: TransferFrameID,
     pub transfer_id: TransferID,
@@ -131,8 +130,7 @@ pub trait TransferFrame {
 }
 
 
-#[cfg_attr(feature="std", derive(Clone, Copy, Debug, Eq, PartialEq, Hash))]
-#[cfg_attr(not(feature="std"), derive(Clone, Copy, Debug, Eq, PartialEq))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct TransferFrameID(u32);
 
 impl TransferFrameID {
@@ -201,8 +199,7 @@ impl From<u8> for TailByte {
 }
 
 
-#[cfg_attr(feature="std", derive(Clone, Copy, Debug, Eq, PartialEq, Hash))]
-#[cfg_attr(not(feature="std"), derive(Clone, Copy, Debug, Eq, PartialEq))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct TransferID(u8);
 
 impl TransferID {

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -3,7 +3,6 @@
 //! The only transfer protocol that is currently supported by the uavcan protocol is CAN2.0B.
 
 use lib::core::convert::{From};
-use lib::core::ops::Index;
 use lib::core::ops::Deref;
 
 use embedded_types;

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -141,8 +141,11 @@ impl FullTransferID {
     }
 }
 
-/// The 29-bit ID of a TransferFrame
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+/// The 29-bit ID of a `TransferFrame`
+///
+/// Frames that will win arbitration can be found by the help of ordering.
+/// If `frame1 < frame2`, then `frame1` will win arbitration over `frame2`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub struct TransferFrameID(u32);
 
 impl TransferFrameID {

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -1,0 +1,51 @@
+/// The TransportFrame is uavcan cores main interface to the outside world
+///
+/// This will in >99% of situations be a CAN2.0B frame
+/// But in theory both CAN-FD and other protocols which gives
+/// similar guarantees as CAN can also be used
+pub trait TransferFrame {
+    fn tail_byte(&self) -> TailByte {
+        TailByte::from(*self.data().last().unwrap())
+    }
+    fn is_start_frame(&self) -> bool {
+        self.tail_byte().start_of_transfer
+    }
+    fn is_end_frame(&self) -> bool {
+        self.tail_byte().end_of_transfer
+    }
+    fn is_single_frame(&self) -> bool {
+        self.is_end_frame() && self.is_start_frame()
+    }
+
+    /// with_data(id: u32, data: &[u]) -> TransportFrame creates a TransportFrame
+    /// with an 28 bits ID and data between 0 and the return value ofget_max_data_length()
+    fn with_data(id: u32,  data: &[u8]) -> Self;
+    fn with_length(id: u32, length: usize) -> Self;
+    fn set_data_length(&mut self, length: usize);
+    fn max_data_length() -> usize;
+    fn data(&self) -> &[u8];
+    fn data_as_mut(&mut self) -> &mut[u8];
+    fn id(&self) -> u32;
+}
+
+pub struct TailByte {
+    start_of_transfer: bool,
+    end_of_transfer: bool,
+    toggle: bool,
+    transfer_id: u8,
+}
+
+impl From<TailByte> for u8 {
+    fn from(tb: TailByte) -> u8 {
+        ((tb.start_of_transfer as u8) << 7) | ((tb.end_of_transfer as u8) << 6) | ((tb.toggle as u8) << 5) | (tb.transfer_id&0x1f)
+    }
+}
+
+impl From<u8> for TailByte {
+    fn from(u: u8) -> TailByte {
+        TailByte{start_of_transfer: (u&(1<<7)) != 0, end_of_transfer: (u&(1<<6)) != 0, toggle: (u&(1<<5)) != 0, transfer_id: u&0x1f}
+    }
+}
+
+
+

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -1,6 +1,18 @@
 use lib::core::convert::{From};
 
 
+pub enum TransmitError {
+    BufferFull,
+}
+
+
+pub trait TransferInterface {
+    type Frame: TransferFrame;
+    fn transmit(&self, frame: &Self::Frame) -> Result<(), TransmitError>;
+    fn receive(&self, identifier: Option<&FullTransferID>) -> Option<Self::Frame>;
+    fn received_completely(&self) -> &[FullTransferID];
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FullTransferID {
     pub frame_id: TransferFrameID,

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -155,6 +155,11 @@ impl From<u32> for TransferFrameID {
 pub struct TransferID(u8);
 
 impl TransferID {
+    pub fn new(value: u8) -> TransferID {
+        assert_eq!(value & !0x1f, 0);
+        TransferID(value)
+    }
+    
     pub fn mask(self, mask: Self) -> Self {
         let TransferID(mut value) = self;
         value = value & u8::from(mask);
@@ -166,13 +171,6 @@ impl From<TransferID> for u8 {
     fn from(tid: TransferID) -> u8 {
         let TransferID(value) = tid;
         value
-    }
-}
-
-impl From<u8> for TransferID {
-    fn from(value: u8) -> TransferID {
-        assert_eq!(value & !0x1f, 0);
-        TransferID(value)
     }
 }
 
@@ -202,7 +200,7 @@ impl TailByte {
     
     pub fn transfer_id(&self) -> TransferID {
         let TailByte(value) = *self;
-        TransferID(value)
+        TransferID::new(value & 0x1f)
     }
 }
 

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -254,5 +254,5 @@ impl TransferFrame for embedded_types::can::ExtendedDataFrame {
     fn set_data_length(&mut self, length: usize) {self.set_data_length(length);}
     fn data(&self) -> &[u8] {&self.data()}
     fn data_as_mut(&mut self) -> &mut [u8] {self.data_as_mut()}
-    fn id(&self) -> TransferFrameID {self.id().clone().into()}
+    fn id(&self) -> TransferFrameID {self.id().into()}
 }

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -240,7 +240,10 @@ impl TransferFrame for embedded_types::can::ExtendedDataFrame {
     const MAX_DATA_LENGTH: usize = 8;
 
     fn new(id: TransferFrameID) -> Self { embedded_types::can::ExtendedDataFrame::new(id.into()) }
-    fn set_data_length(&mut self, length: usize) {self.set_data_length(length);}
+    fn set_data_length(&mut self, length: usize) {
+        assert!(length <= Self::MAX_DATA_LENGTH, "ExtendedDataFrame::set_data_length() needs the length to be less than 8");
+        self.set_data_length(length);
+    }
     fn data(&self) -> &[u8] {&self.data()}
     fn data_as_mut(&mut self) -> &mut [u8] {self.data_as_mut()}
     fn id(&self) -> TransferFrameID {self.id().into()}

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -43,9 +43,20 @@ impl TailByte {
         value & (1<<7) != 0
     }
 
-    pub fn end_of_transfer(&self) -> bool {unimplemented!()}
-    pub fn toggle(&self) -> bool {unimplemented!()}
-    pub fn transfer_id(&self) -> u8 {unimplemented!()}
+    pub fn end_of_transfer(&self) -> bool {
+        let TailByte(value) = *self;
+        value & (1<<6) != 0
+    }
+    
+    pub fn toggle(&self) -> bool {
+        let TailByte(value) = *self;
+        value & (1<<5) != 0
+    }
+    
+    pub fn transfer_id(&self) -> TransferID {
+        let TailByte(value) = *self;
+        TransferID(value)
+    }
 }
 
 

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -1,3 +1,7 @@
+//! This module contains everything related to the transfer protocol that will be used to transmit the uavcan frame
+//!
+//! The only transfer protocol that is currently supported by the uavcan protocol is CAN2.0B.
+
 use lib::core::convert::{From};
 
 

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -48,22 +48,6 @@ pub trait TransferInterface
     fn completed_receives(&self, identifier: FullTransferID, mask: FullTransferID) -> Self::IDContainer;
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub struct FullTransferID {
-    pub frame_id: TransferFrameID,
-    pub transfer_id: TransferID,
-}
-
-impl FullTransferID {
-    pub fn mask(self, mask: Self) -> Self {
-        FullTransferID{
-            frame_id: self.frame_id.mask(mask.frame_id),
-            transfer_id: self.transfer_id.mask(mask.transfer_id),
-        }
-    }
-}
-
-
 /// `TransferFrame` is a CAN like frame that can be sent over a network
 ///
 /// For a frame to work it need to have a 28 bit ID, and a payload of
@@ -131,6 +115,21 @@ pub trait TransferFrame {
 
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct FullTransferID {
+    pub frame_id: TransferFrameID,
+    pub transfer_id: TransferID,
+}
+
+impl FullTransferID {
+    pub fn mask(self, mask: Self) -> Self {
+        FullTransferID{
+            frame_id: self.frame_id.mask(mask.frame_id),
+            transfer_id: self.transfer_id.mask(mask.transfer_id),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct TransferFrameID(u32);
 
 impl TransferFrameID {
@@ -152,6 +151,31 @@ impl From<u32> for TransferFrameID {
     fn from(value: u32) -> TransferFrameID {
         assert_eq!(value & !0x1fff_ffff, 0);
         TransferFrameID(value)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct TransferID(u8);
+
+impl TransferID {
+    pub fn mask(self, mask: Self) -> Self {
+        let TransferID(mut value) = self;
+        value = value & u8::from(mask);
+        TransferID(value)        
+    }
+}
+
+impl From<TransferID> for u8 {
+    fn from(tid: TransferID) -> u8 {
+        let TransferID(value) = tid;
+        value
+    }
+}
+
+impl From<u8> for TransferID {
+    fn from(value: u8) -> TransferID {
+        assert_eq!(value & !0x1f, 0);
+        TransferID(value)
     }
 }
 
@@ -195,32 +219,6 @@ impl From<TailByte> for u8 {
 impl From<u8> for TailByte {
     fn from(value: u8) -> TailByte {
         TailByte(value)
-    }
-}
-
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub struct TransferID(u8);
-
-impl TransferID {
-    pub fn mask(self, mask: Self) -> Self {
-        let TransferID(mut value) = self;
-        value = value & u8::from(mask);
-        TransferID(value)        
-    }
-}
-
-impl From<TransferID> for u8 {
-    fn from(tid: TransferID) -> u8 {
-        let TransferID(value) = tid;
-        value
-    }
-}
-
-impl From<u8> for TransferID {
-    fn from(value: u8) -> TransferID {
-        assert_eq!(value & !0x1f, 0);
-        TransferID(value)
     }
 }
 

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -103,7 +103,7 @@ impl From<TransferID> for u8 {
 
 impl From<u8> for TransferID {
     fn from(value: u8) -> TransferID {
-        assert_eq!(value & 0x1f, 0);
+        assert_eq!(value & !0x1f, 0);
         TransferID(value)
     }
 }

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -5,6 +5,7 @@
 use lib::core::convert::{From};
 
 
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TransmitError {
     BufferFull,
 }

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -20,7 +20,7 @@ pub trait TransferInterface<'a>
     /// The TransferFrame associated with this interface.
     type Frame: TransferFrame;
 
-    /// Put a `TransferFrame` in the transfer buffer (or transmit it on the bus) or report an error.
+    /// Put a `TransferFrame` in the transfer buffer (or transmit it on the bus) or return `Err(IOError::BufferExhausted)` if buffer is full.
     ///
     /// To avoid priority inversion the new frame needs to be prioritized inside the interface as it would on the bus.
     /// When reprioritizing the `TransferInterface` must for equal ID frames respect the order they were attempted transmitted in.

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -19,34 +19,64 @@ pub struct FullTransferID {
     pub transfer_id: TransferID,
 }
 
-/// The TransportFrame is uavcan cores main interface to the outside world
+/// The TransferFrame is a CAN like frame that can be sent over a network
 ///
-/// This will in >99% of situations be a CAN2.0B frame
-/// But in theory both CAN-FD and other protocols which gives
-/// similar guarantees as CAN can also be used
+/// For a frame to work it need to have a 28 bit ID, and a payload of
+/// at least 4 bytes. Guarantee that frames are delivered in order
+/// and correctness check is needed as well.
+///
+/// The uavcan protocol defines how this works with a CAN2.0B frame
 pub trait TransferFrame {
+    /// Maximum data length the transfer protocol supports.
     const MAX_DATA_LENGTH: usize;
 
     /// Create a new TransferFrame with id: id, and length 0.
+    /// Data length can be changed with `set_data_length(&self)`.
+    /// Data can be changed with `data_as_mut(&mut self)`.
     fn new(id: TransferFrameID) -> Self;
+
+    /// Returns the 28 bit ID of this TransferFrame.
+    ///
+    /// When deciding which frame that will be transmitted,
+    /// the ID is used to prioritze (lower ID means higher priority)
+    fn id(&self) -> TransferFrameID;
+
+    /// Returns a slice with the data in this TransferFrame
+    ///
+    /// Length can be found by checking the length
+    /// of this slice `self.data().len()`
+    fn data(&self) -> &[u8];
+
+    /// Returns a mutable slice with the data in this TransferFrame
+    /// use this method to set/change the data inside this TransferFrame
+    fn data_as_mut(&mut self) -> &mut[u8];
+
+    /// Set the data length of this TransferFrame
+    ///
+    /// ## Panics
+    /// `set_data_lengt(&mut self, length: usize)` should panic if `length > T::MAX_DATA_LENGTH`
+    fn set_data_length(&mut self, length: usize);
     
+    /// Returns the tail byte of the TransferFrame assuming the current length
     fn tail_byte(&self) -> TailByte {
         TailByte::from(*self.data().last().unwrap())
     }
+
+    /// Checks the tail byte if this frame is a start frame and return the result
     fn is_start_frame(&self) -> bool {
         self.tail_byte().start_of_transfer()
     }
+    
+    /// Checks the tail byte if this frame is an end frame and return the result
     fn is_end_frame(&self) -> bool {
         self.tail_byte().end_of_transfer()
     }
+    
+    /// Checks the tail byte if this is both a start frame and an end frame and return the result
     fn is_single_frame(&self) -> bool {
         self.is_end_frame() && self.is_start_frame()
     }
 
-    fn set_data_length(&mut self, length: usize);
-    fn data(&self) -> &[u8];
-    fn data_as_mut(&mut self) -> &mut[u8];
-    fn id(&self) -> TransferFrameID;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -4,6 +4,7 @@
 
 use lib::core::convert::{From};
 use lib::core::ops::Index;
+use lib::core::ops::Deref;
 
 use embedded_types;
 
@@ -19,16 +20,15 @@ pub enum TransmitError {
 /// while making sure that transfer frames with the same ID is transmitted in the same order as they was added in the transmit buffer.
 ///
 /// Receiving frames must be returned in the same order they were received by the interface.
-pub trait TransferInterface
-    where <<Self as TransferInterface>::IDContainer as IntoIterator>::IntoIter : ExactSizeIterator
+pub trait TransferInterface<'a>
 {
     /// The TransferFrame associated with this interface.
     type Frame: TransferFrame;
 
     /// A container for `FullTransferID`s that is indexable and iterable.
     ///
-    /// Suitable types are `&[FullTransferID]` or `Vec<FullTransferID` (if using the std library)
-    type IDContainer: IntoIterator<Item=FullTransferID> + Index<usize, Output=FullTransferID>;
+    /// Suitable types are `&[FullTransferID]` or `Box<[FullTransferID]>` (which can be constructed from `Vec<FullTransferID>` by calling `into_boxed_slice`
+    type IDContainer: Deref<Target=[FullTransferID]>;
 
     /// Put a `TransferFrame` in the transfer buffer (or transmit it on the bus) or report an error.
     ///

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -26,6 +26,9 @@ pub struct FullTransferID {
 /// similar guarantees as CAN can also be used
 pub trait TransferFrame {
     const MAX_DATA_LENGTH: usize;
+
+    /// Create a new TransferFrame with id: id, and length 0.
+    fn new(id: TransferFrameID) -> Self;
     
     fn tail_byte(&self) -> TailByte {
         TailByte::from(*self.data().last().unwrap())
@@ -40,10 +43,6 @@ pub trait TransferFrame {
         self.is_end_frame() && self.is_start_frame()
     }
 
-    /// with_data(id: u32, data: &[u]) -> TransportFrame creates a TransportFrame
-    /// with an 28 bits ID and data between 0 and the return value ofget_max_data_length()
-    fn with_data(id: TransferFrameID,  data: &[u8]) -> Self;
-    fn with_length(id: TransferFrameID, length: usize) -> Self;
     fn set_data_length(&mut self, length: usize);
     fn data(&self) -> &[u8];
     fn data_as_mut(&mut self) -> &mut[u8];

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -25,6 +25,8 @@ pub struct FullTransferID {
 /// But in theory both CAN-FD and other protocols which gives
 /// similar guarantees as CAN can also be used
 pub trait TransferFrame {
+    const MAX_DATA_LENGTH: usize;
+    
     fn tail_byte(&self) -> TailByte {
         TailByte::from(*self.data().last().unwrap())
     }
@@ -43,7 +45,6 @@ pub trait TransferFrame {
     fn with_data(id: TransferFrameID,  data: &[u8]) -> Self;
     fn with_length(id: TransferFrameID, length: usize) -> Self;
     fn set_data_length(&mut self, length: usize);
-    fn max_data_length() -> usize;
     fn data(&self) -> &[u8];
     fn data_as_mut(&mut self) -> &mut[u8];
     fn id(&self) -> TransferFrameID;

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -31,9 +31,8 @@ pub trait TransferFrame {
 pub struct TailByte(u8);
 
 impl TailByte {
-    pub fn new(start_of_transfer: bool, end_of_transfer: bool, toggle: bool, transfer_id: u8) -> Self {
-        assert_eq!(transfer_id & 0x1f, 0x00);
-        TailByte( ((start_of_transfer as u8)<<7) | ((end_of_transfer as u8)<<6) | ((toggle as u8)<<5) | (transfer_id<<0) )
+    pub fn new(start_of_transfer: bool, end_of_transfer: bool, toggle: bool, transfer_id: TransferID) -> Self {
+        TailByte( ((start_of_transfer as u8)<<7) | ((end_of_transfer as u8)<<6) | ((toggle as u8)<<5) | (u8::from(transfer_id)) )
     }
     
     pub fn start_of_transfer(&self) -> bool {
@@ -60,5 +59,20 @@ impl From<u8> for TailByte {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TransferID(u8);
 
+impl From<TransferID> for u8 {
+    fn from(tid: TransferID) -> u8 {
+        let TransferID(value) = tid;
+        value
+    }
+}
+
+impl From<u8> for TransferID {
+    fn from(value: u8) -> TransferID {
+        assert_eq!(value & 0x1f, 0);
+        TransferID(value)
+    }
+}
 


### PR DESCRIPTION
## This PR (in scope)

1. Create types for identifiers instead of using u32 and u8. The reason for this is
    - Being able to catch type errors statically.
    - These IDs are 4bit and 29bit. Using a specialized type it's easier to guarantee that nonsensical values won't exist.
2. Defines a part of the interface to the can drivers/ports. Namely the part that is needed for reception/transmission.

## This PR is not trying to (out of scope)
 - Define construction/configuration of can interfaces
 - Make the interface fault tolerant (e.g. handle a full receive buffer), but it should allow this kind of features to be added later on.
- Define how several interfaces can use the same TX/RX buffers, this must be handled in the driver. Perhaps in a structure similar to libuavcans ICanDriver

## Things that might require this interface to change in the future
- Adding timestamps when transmitting/receiving can frames, this may be an optional return value. It can also be a new method belonging to a new trait. If the second approach is taken the type system can be used to statically settle if a can node can be used as a time server.

## Rationale
- In #7 I explain [why I want to settle this can interface before anything else](https://github.com/UAVCAN/uavcan.rs/issues/7#issuecomment-332437783) and [why I think the buffer should exist in the driver](https://github.com/UAVCAN/uavcan.rs/issues/7#issuecomment-333066571) (which is highly relevant to how the interface API is constructed)
- I've decided to call everything related with CAN for transfer and make it generic. The reason for this is
    - Uavcan will hopefully in not so distant also support CAN-FD, let's be ready.
    - If some crazy person wants to log/send uavcan messages over TCP, who am I to stop him.
- The rest of the workings is explained in the doc strings
