### PR TITLE
Dynamic array improvements

### DIFF
--- a/uavcan/src/types.rs
+++ b/uavcan/src/types.rs
@@ -48,7 +48,7 @@ trait PrimitiveType : Sized + Copy + ::Serializable {
 /// ```
 #[derive(Clone)]
 pub struct Dynamic<T> {
-    array: T,
+    array: lib::core::mem::ManuallyDrop<T>,
     current_length: usize,
 }
 
@@ -111,7 +111,7 @@ macro_rules! impl_array{
             /// Constructs a new empty `Dynamic` array
             pub fn new() -> Self {
                 Self{
-                    array: unsafe{ lib::core::mem::uninitialized() },
+                    array: lib::core::mem::ManuallyDrop::new(unsafe{ lib::core::mem::uninitialized() }),
                     current_length: 0,
                 }
             }
@@ -346,6 +346,17 @@ macro_rules! impl_array{
         
     };
 }
+
+impl<T> Drop for Dynamic<T> {
+    fn drop(&mut self) {
+        // Since const generics doesn't work we can't deconstruct elements inside arrays when it's beeing dropped
+        // This might in extreme cases cause memory leaks and other weirdness from deconstructors not running
+        // This isn't good but not UD or unsafe either.
+        // Fix as soon as const generics lands
+    }
+}
+        
+
 
 impl_array!([(1, 1), (2, 2), (3, 2), (4, 3), (5, 3), (6, 3), (7, 3), (8, 4), (9, 4)]);
 impl_array!([(10, 4), (11, 4), (12, 4), (13, 4), (14, 4), (15, 4), (16, 5), (17, 5), (18, 5), (19, 5)]);

--- a/uavcan/src/types.rs
+++ b/uavcan/src/types.rs
@@ -39,11 +39,13 @@ trait PrimitiveType : Sized + Copy + ::Serializable {
 ///
 /// # Examples
 /// ```
+/// use std::str;
 /// use uavcan::types::*;
 ///
 /// let dynamic_array = Dynamic::<[u8; 90]>::with_data("dynamic array".as_bytes());
 ///
 /// assert_eq!(dynamic_array.length(), 13);
+/// assert_eq!(str::from_utf8(dynamic_array.as_ref()).unwrap(), "dynamic array");
 ///
 /// ```
 #[derive(Clone)]

--- a/uavcan/src/types.rs
+++ b/uavcan/src/types.rs
@@ -749,6 +749,14 @@ mod tests {
     use types::*;
 
     #[test]
+    fn dynamic_array_with_data() {
+        let a: [u8; 5] = [1, 2, 3, 4, 5];
+        let d = Dynamic::<[u8; 15]>::with_data(&a);
+        
+        assert_eq!(d.as_ref(), &a);
+    }
+    
+    #[test]
     fn dynamic_array_push() {
         let mut a = Dynamic::<[u8; 15]>::new();
         assert_eq!(a.as_ref(), &[]);

--- a/uavcan/src/types.rs
+++ b/uavcan/src/types.rs
@@ -158,7 +158,7 @@ macro_rules! impl_array{
             pub fn shrink(&mut self, length: usize) {
                 assert!(length <= self.current_length, "Dynamic::shrink() can only be used to shrink array");
                 for i in length..self.current_length {
-                    let mut temp: T = lib::core::mem::replace(&mut self.array[i], unsafe{ lib::core::mem::uninitialized() } );
+                    let temp: T = lib::core::mem::replace(&mut self.array[i], unsafe{ lib::core::mem::uninitialized() } );
                     drop(temp);
                 }
                 self.current_length = length;

--- a/uavcan/src/types.rs
+++ b/uavcan/src/types.rs
@@ -48,7 +48,6 @@ trait PrimitiveType : Sized + Copy + ::Serializable {
 /// assert_eq!(str::from_utf8(dynamic_array.as_ref()).unwrap(), "dynamic array");
 ///
 /// ```
-#[derive(Clone)]
 pub struct Dynamic<T> {
     array: lib::core::mem::ManuallyDrop<T>,
     current_length: usize,
@@ -346,6 +345,16 @@ macro_rules! impl_array{
                     write!(f, "{:?}, ", self.array[i])?;
                 }
                 write!(f, "]}}")
+            }
+        }
+        
+        impl<T: Clone> Clone for Dynamic<[T; $size]> {
+            fn clone(&self) -> Self {
+                let mut a = Self::new();
+                for i in 0..self.current_length {
+                    a.push(self.array[i].clone());
+                }
+                a
             }
         }
         
@@ -756,6 +765,15 @@ mod tests {
         let d = Dynamic::<[u8; 15]>::with_data(&a);
         
         assert_eq!(d.as_ref(), &a);
+    }
+    
+    #[test]
+    fn dynamic_array_clone() {
+        let a: [u8; 5] = [1, 2, 3, 4, 5];
+        let d1 = Dynamic::<[u8; 15]>::with_data(&a);
+        let d2 = d1.clone();
+        
+        assert_eq!(d1, d2);
     }
     
     #[test]

--- a/uavcan/src/types.rs
+++ b/uavcan/src/types.rs
@@ -169,7 +169,7 @@ macro_rules! impl_array{
             fn grow(&mut self, length: usize) where T: Default {
                 assert!(length > self.current_length);
                 for i in self.current_length..length {
-                    self.array[i] = T::default();
+                    unsafe{lib::core::ptr::write(&mut self.array[i], T::default())};
                 }
                 self.current_length = length;
             }

--- a/uavcan/src/types.rs
+++ b/uavcan/src/types.rs
@@ -738,3 +738,25 @@ impl PrimitiveType for bool {
     }
 }
 impl_serializeable!(bool, 1);
+
+
+
+
+#[cfg(test)]
+mod tests {
+
+    use *;
+    use types::*;
+
+    #[test]
+    fn dynamic_array_push() {
+        let mut a = Dynamic::<[u8; 15]>::new();
+        assert_eq!(a.as_ref(), &[]);
+
+        a.push(12);
+        assert_eq!(a.as_ref(), &[12]);
+        
+        a.push(120);
+        assert_eq!(a.as_ref(), &[12, 120]);
+    }
+}


### PR DESCRIPTION
By making Dynamic keep track of how much of the data that is initialized better performance, usability and less surprising behaviour is acheived.

This might be enough to say #46 is fixed, but since these methods will require a review after some use, makes me want to keep it open for now.