### PR TITLE
Transfer subscription

### DIFF
--- a/uavcan/src/lib.rs
+++ b/uavcan/src/lib.rs
@@ -53,7 +53,7 @@ mod deserializer;
 mod frame_assembler;
 mod serializer;
 mod frame_disassembler;
-mod node;
+pub mod node;
 
 use bit_field::BitField;
 

--- a/uavcan/src/node.rs
+++ b/uavcan/src/node.rs
@@ -49,7 +49,7 @@ impl NodeID {
 ///
 /// Allows implementation of application level features genericaly for all types of Uavcan Nodes.
 pub trait Node<I: TransferInterface> {
-    fn transmit_message<T: Struct + Message>(&self, message: T) -> Result<(), IOError>;
+    fn broadcast<T: Struct + Message>(&self, message: T) -> Result<(), IOError>;
     fn subscribe<T: Struct + Message>(&self) -> Result<Subscriber<T, I>, ()>;
 }
 
@@ -145,7 +145,7 @@ impl<'a, I> SimpleNode<'a, I>
 
 impl<'a, I> Node<I> for SimpleNode<'a, I>
     where I: 'a + TransferInterface {
-    fn transmit_message<T: Struct + Message>(&self, message: T) -> Result<(), IOError> {
+    fn broadcast<T: Struct + Message>(&self, message: T) -> Result<(), IOError> {
         let priority = 0;
         let transfer_id = TransferID::new(0);
         

--- a/uavcan/src/node.rs
+++ b/uavcan/src/node.rs
@@ -123,17 +123,17 @@ impl <T: Struct + Message, I: TransferInterface> Subscriber<T, I> {
 ///
 /// Supports the features required by `Node` trait
 #[derive(Debug)]
-pub struct SimpleNode<I>
-    where I: TransferInterface {
-    interface: I,
+pub struct SimpleNode<'a, I>
+    where I: 'a + TransferInterface {
+    interface: &'a I,
     config: NodeConfig,
     phantom: PhantomData<I>,
 }
 
 
-impl<I> SimpleNode<I>
-    where I: TransferInterface {
-    pub fn new(interface: I, config: NodeConfig) -> Self {
+impl<'a, I> SimpleNode<'a, I>
+    where I: 'a + TransferInterface {
+    pub fn new(interface: &'a I, config: NodeConfig) -> Self {
         SimpleNode{
             interface: interface,
             config: config,
@@ -143,8 +143,8 @@ impl<I> SimpleNode<I>
 }
 
 
-impl<I> Node<I> for SimpleNode<I>
-    where I: TransferInterface {
+impl<'a, I> Node<I> for SimpleNode<'a, I>
+    where I: 'a + TransferInterface {
     fn transmit_message<T: Struct + Message>(&self, message: T) -> Result<(), IOError> {
         let priority = 0;
         let transfer_id = TransferID::new(0);

--- a/uavcan/src/node.rs
+++ b/uavcan/src/node.rs
@@ -87,7 +87,7 @@ pub struct Subscriber<T: Struct + Message, I: TransferInterface> {
 }
 
 impl <T: Struct + Message, I: TransferInterface> Subscriber<T, I> {
-    pub fn new(transfer_subscriber: I::Subscriber) -> Self {
+    fn new(transfer_subscriber: I::Subscriber) -> Self {
         Subscriber{
             transfer_subscriber: transfer_subscriber,
             phantom: PhantomData,

--- a/uavcan/src/node.rs
+++ b/uavcan/src/node.rs
@@ -135,28 +135,29 @@ impl <T: Struct + Message, I: TransferInterface> Subscriber<T, I> {
 /// This type of node lack some features that the `FullNode` provides,
 /// but is in turn suitable for highly resource constrained systems.
 #[derive(Debug)]
-pub struct SimpleNode<'a, I>
-    where I: 'a + TransferInterface {
-    interface: &'a I,
+pub struct SimpleNode<I, D>
+    where I: TransferInterface,
+          D: ::lib::core::ops::Deref<Target=I> {
+    interface: D,
     config: NodeConfig,
-    phantom: PhantomData<I>,
 }
 
 
-impl<'a, I> SimpleNode<'a, I>
-    where I: 'a + TransferInterface {
-    pub fn new(interface: &'a I, config: NodeConfig) -> Self {
+impl<I, D> SimpleNode<I, D>
+    where I: TransferInterface,
+          D: ::lib::core::ops::Deref<Target=I> {
+    pub fn new(interface: D, config: NodeConfig) -> Self {
         SimpleNode{
             interface: interface,
             config: config,
-            phantom: PhantomData,
         }
     }
 }
 
 
-impl<'a, I> Node<I> for SimpleNode<'a, I>
-    where I: 'a + TransferInterface {
+impl<I, D> Node<I> for SimpleNode<I, D>
+    where I: TransferInterface,
+          D: ::lib::core::ops::Deref<Target=I> {
     fn broadcast<T: Struct + Message>(&self, message: T) -> Result<(), IOError> {
         let priority = 0;
         let transfer_id = TransferID::new(0);

--- a/uavcan/src/node.rs
+++ b/uavcan/src/node.rs
@@ -80,6 +80,7 @@ impl Default for NodeConfig {
 }
 
 
+/// A subscription handle used to receive a specific `Message`
 #[derive(Debug)]
 pub struct Subscriber<T: Struct + Message, I: TransferInterface> {
     transfer_subscriber: I::Subscriber,
@@ -94,7 +95,10 @@ impl <T: Struct + Message, I: TransferInterface> Subscriber<T, I> {
         }
     }
 
-    pub fn receive_message(&self) -> Result<T, IOError> {
+    /// Receives a message that is subscribed on.
+    ///
+    /// Messages are returned in a manner that respects the `TransferFrameID` priority.
+    pub fn receive(&self) -> Result<T, IOError> {
         // TODO: mind the priority!
         if let Some(end_frame) = self.transfer_subscriber.find(|x| x.is_end_frame()) {
             let mut assembler = FrameAssembler::new();

--- a/uavcan/src/node.rs
+++ b/uavcan/src/node.rs
@@ -66,6 +66,7 @@ pub trait Node<I: TransferInterface> {
 /// node_config.id = Some(NodeID::new(127));
 ///
 /// ```
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NodeConfig {
     pub id: Option<NodeID>,
 }
@@ -79,6 +80,7 @@ impl Default for NodeConfig {
 }
 
 
+#[derive(Debug)]
 pub struct Subscriber<T: Struct + Message, I: TransferInterface> {
     transfer_subscriber: I::Subscriber,
     phantom: PhantomData<T>,
@@ -116,6 +118,7 @@ impl <T: Struct + Message, I: TransferInterface> Subscriber<T, I> {
 /// A minimal featured Uavcan node
 ///
 /// Supports the features required by `Node` trait
+#[derive(Debug)]
 pub struct SimpleNode<I>
     where I: TransferInterface {
     interface: I,

--- a/uavcan/src/node.rs
+++ b/uavcan/src/node.rs
@@ -125,15 +125,9 @@ impl<'a, I> Node for SimpleNode<'a, I>
             unimplemented!("Resolvation of type id is not supported yet")
         };
 
-        let identifier = FullTransferID {
-            frame_id: TransferFrameID::new(id),
-            transfer_id: TransferID::new(0),
-        };
-        let mask = FullTransferID {
-            frame_id: TransferFrameID::new(id),
-            transfer_id: TransferID::new(0),
-        };
-
+        let identifier = TransferFrameID::new(id);
+        let mask = TransferFrameID::new(id);
+        
         if let Some(id) = self.interface.completed_receive(identifier, mask) {
             let mut assembler = FrameAssembler::new();
             loop {

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -28,7 +28,7 @@ pub trait TransferInterface<'a> {
     /// Receive a transfer frame matching `identifier`.
     ///
     /// It's important that `receive` returns frames in the same order they were received from the bus.
-    fn receive(&self, identifier: &FullTransferID) -> Option<Self::Frame>;
+    fn receive(&self, identifier: &TransferFrameID) -> Option<Self::Frame>;
 
     /// Returns a FullTransferID that satisfies the following:
     ///
@@ -37,13 +37,11 @@ pub trait TransferInterface<'a> {
     /// 2. There exists an end_frame (`TransferFrame::is_end_frame(&self)`is asserted) with this `FullTransferID` in the receive buffer.
     ///
     /// 3. If multiple completed transfers matches, the one with highest priority will be returned (based on arbitration off `TransferFrameID`).
-    ///
-    /// 4. If multiple transfers with the same `TransferFrameID` matches, the `FullTransferID` of the one received first will be returned.
     fn completed_receive(
         &self,
-        identifier: FullTransferID,
-        mask: FullTransferID,
-    ) -> Option<FullTransferID>;
+        identifier: TransferFrameID,
+        mask: TransferFrameID,
+    ) -> Option<TransferFrameID>;
 }
 
 /// `TransferFrame` is a CAN like frame that can be sent over a network

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -27,9 +27,9 @@ pub trait TransferInterface {
     /// When reprioritizing the `TransferInterface` must for equal ID frames respect the order they were attempted transmitted in.
     fn transmit(&self, frame: &Self::Frame) -> Result<(), IOError>;
     
-    /// Create a receive buffer
+    /// Create a `TransferSubscriber` with a receive buffer for incoming `TransferFrames` that matches `filter`.
     ///
-    /// The TransferFrames matching the filter will be put in this buffer. 
+    /// All TransferFrames matching `filter` will be put in this buffer. 
     fn subscribe(&self, filter: TransferFrameIDFilter) -> Result<Self::Subscriber, ()>;
 }
 
@@ -38,16 +38,18 @@ pub trait TransferInterface {
 /// Orderings referes to:
 ///
 /// 1. Should be ordered after the `TransferFrameID` Priority.
-/// 2. For equal `TransferFrameID` should ordered after receive order.
+/// 2. For equal `TransferFrameID`, frames should be in the same order they were received.
 pub trait TransferSubscriber {
     type Frame: TransferFrame;
     
     /// Receive a frame matching the indentifier.
     ///
-    /// It's important that `receive` returns frames in the same order they were received from the bus.
+    /// When a frame is received it will be removed from the buffer.
+    ///
+    /// It's important that `receive` returns frames in the correct order.
     fn receive(&self, identifier: &TransferFrameID) -> Option<Self::Frame>;
 
-    /// Returns a reference to the first frame satisfying the predicate. Does not remove the frame from the buffer.
+    /// Returns a copy of the first frame satisfying the predicate. Does not remove the frame from the buffer.
     fn find<P>(&self, predicate: P) -> Option<Self::Frame> where P: FnMut(&Self::Frame) -> bool;
 }
 

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -170,6 +170,26 @@ impl From<TransferFrameID> for u32 {
     }
 }
 
+/// A filter for `TransferFrameID`
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+pub struct TransferFrameIDFilter{
+    mask: u32,
+    value: u32,
+}
+
+impl TransferFrameIDFilter {
+    fn new(mask: u32, value: u32) -> Self {
+        TransferFrameIDFilter{
+            mask: mask,
+            value: value,
+        }
+    }
+
+    fn is_match(&self, value: TransferFrameID) -> bool {
+        self.mask & u32::from(value) == self.mask & self.value
+    }
+}
+
 /// The 5-bit ID used to distinguish consecutive transfers
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct TransferID(u8);

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -49,6 +49,12 @@ pub trait TransferSubscriber {
     /// It's important that `receive` returns frames in the correct order.
     fn receive(&self, identifier: &TransferFrameID) -> Option<Self::Frame>;
 
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all elements e such that `f(&e)` returns false.
+    /// This method must operate in place and preserves the order of the retained elements.
+    fn retain<F>(&self, f: F) where F: FnMut(&Self::Frame) -> bool;
+
     /// Returns a copy of the first frame satisfying the predicate. Does not remove the frame from the buffer.
     fn find<P>(&self, predicate: P) -> Option<Self::Frame> where P: FnMut(&Self::Frame) -> bool;
 }


### PR DESCRIPTION
This change introduce subscribers that subscribes on message types. The reasons for this change is:
1. By needing to subscribe on messages we can filter everything at the driver with logic that should be relatively easy to implement.
2. It's easy to free frames that are no longer subscribed to (can't be read in the future). This makes it simpler to avoid memory leaks.
3. If one type is subscribed to but never read (memory leak caused by the application) this can be detected and handled as an error by the library. This can be done without causing degradation for other messages that is subscribed on.
4. For very primitive nodes, this can be combined with static allocated (with lazy static subscribers) buffers that allows very low memory use as long as only a few messages are subscribed on.