### PR TITLE
Use the clippy component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ rust:
   - beta
   - nightly
 
+before_script:
+  - |
+    if [ $ACTION == "clippy" ]
+    then
+      rustup component add clippy-preview --toolchain=nightly
+    fi
+
 env:
   - TEST_DIR="uavcan" ACTION="test" FLAGS="--no-default-features"
   - TEST_DIR="uavcan" ACTION="test" FLAGS=""
@@ -14,6 +21,6 @@ env:
 matrix:
   include:
     - rust: nightly
-      env: TEST_DIR="uavcan" ACTION="build" FLAGS="--features clippy"
+      env: TEST_DIR="uavcan" ACTION="clippy"
   
 script: cd $TEST_DIR && ./travis.sh

--- a/uavcan/Cargo.toml
+++ b/uavcan/Cargo.toml
@@ -23,9 +23,6 @@ bit_field = "0.8.0"
 uavcan-derive = {path = "../uavcan-derive"}
 embedded_types = "0.3.0"
 
-clippy = {version = "*", optional = true}
-
-
 [dependencies.half]
 version = "1.0.0"
 default-features = false


### PR DESCRIPTION
Some of the latest PR have broken in CI due to regressions in clippy. This has been a problem in the whole rust ecosystem and the clippy component was created as a solution. This PR will make uavcan.rs use the clippy component.