### PR TITLE
Switch to no_std

### DIFF
--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -12,6 +12,7 @@ arrayvec = "0.5.2"
 
 [dependencies.uavcan]
 path = "../../uavcan"
+features = ["std"]
 
 # idk what to do with workspaces
 [workspace]

--- a/uavcan/Cargo.toml
+++ b/uavcan/Cargo.toml
@@ -22,3 +22,7 @@ num-traits = "0.2"
 bitfield = "0.13"
 crc-any = "2.3.5"
 arrayvec = "0.5.2"
+
+[features]
+default = []
+std = []

--- a/uavcan/Cargo.toml
+++ b/uavcan/Cargo.toml
@@ -24,5 +24,5 @@ crc-any = "2.3.5"
 arrayvec = "0.5.2"
 
 [features]
-default = []
+default = ["std"]
 std = []

--- a/uavcan/src/lib.rs
+++ b/uavcan/src/lib.rs
@@ -21,7 +21,13 @@
 //! and storage backends. Application level functionality can live on top of
 //! this. I can see issues with this running into issues in multi-threaded
 //! environments, but I'll get to those when I get to them.
+#![no_std]
 #![feature(generic_associated_types)]
+
+#[allow(unused_imports)]
+#[cfg(any(feature = "std", test))]
+#[macro_use]
+extern crate std;
 
 #[macro_use]
 extern crate num_derive;

--- a/uavcan/src/session/mod.rs
+++ b/uavcan/src/session/mod.rs
@@ -11,8 +11,10 @@ use crate::internal::InternalRxFrame;
 use crate::transfer::Transfer;
 use crate::types::*;
 
+#[cfg(feature = "std")]
 mod std_vec;
 
+#[cfg(feature = "std")]
 pub use std_vec::StdVecSessionManager;
 
 /// Session-related errors, caused by reception errors.

--- a/uavcan/src/session/std_vec.rs
+++ b/uavcan/src/session/std_vec.rs
@@ -7,6 +7,7 @@ use crate::session::*;
 use crate::types::NodeId;
 
 use std::collections::HashMap;
+use std::vec::Vec;
 
 /// Internal session object.
 #[derive(Clone, Debug)]
@@ -173,8 +174,8 @@ impl<T: crate::transport::SessionMetadata> StdVecSessionManager<T> {
             Some(pos) => {
                 self.subscriptions[pos] = Subscription::new(subscription);
                 Ok(())
-            },
-            None => Err(SubscriptionError::SubscriptionDoesNotExist)
+            }
+            None => Err(SubscriptionError::SubscriptionDoesNotExist),
         }
     }
 


### PR DESCRIPTION
As to use the crate on embedded systems, what is an intended goal for the rust crate, it should be no_std by default.
A feature called "std" should enable std support for environments where the std lib can be used.

Implemented it like the example [here](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification).

It's the first step to implement generalized timing and no_std session manager [ref to goals](https://forum.uavcan.org/t/uavcan-rs-v1-progress-tracking/1430).