### PR TITLE
Generic time impl #71

### DIFF
--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 socketcan = "1.7.0"
 arrayvec = "0.5.2"
+embedded-time = "0.12.0"
 
 [dependencies.uavcan]
 path = "../../uavcan"

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -1,48 +1,57 @@
-use uavcan::{Node, Priority, Subscription, TransferKind, transfer::Transfer, types::TransferId};
+use embedded_time::duration::Milliseconds;
+use embedded_time::Clock;
 use uavcan::session::StdVecSessionManager;
-use uavcan::transport::can::{Can, CanMetadata, CanFrame as UavcanFrame};
+use uavcan::time::StdClock;
+use uavcan::transport::can::{Can, CanFrame as UavcanFrame, CanMetadata};
+use uavcan::{transfer::Transfer, types::TransferId, Node, Priority, Subscription, TransferKind};
 
-use socketcan::{CANFrame, CANSocket};
 use arrayvec::ArrayVec;
+use socketcan::{CANFrame, CANSocket};
 
 fn main() {
-    let mut session_manager = StdVecSessionManager::<CanMetadata>::new();
-    session_manager.subscribe(Subscription::new(
-        TransferKind::Message,
-        7509, // TODO check
-        7,
-        core::time::Duration::from_millis(500)
-    )).unwrap();
-    session_manager.subscribe(Subscription::new(
-        TransferKind::Message,
-        100,
-        200,
-        core::time::Duration::from_millis(500)
-    )).unwrap();
-    let mut node: Node<StdVecSessionManager<CanMetadata>, Can> = Node::new(Some(42), session_manager);
-
+    let clock = StdClock::new();
+    let mut session_manager = StdVecSessionManager::<CanMetadata, Milliseconds>::new();
+    session_manager
+        .subscribe(Subscription::new(
+            TransferKind::Message,
+            7509, // TODO check
+            7,
+            embedded_time::duration::Milliseconds(500),
+        ))
+        .unwrap();
+    session_manager
+        .subscribe(Subscription::new(
+            TransferKind::Message,
+            100,
+            200,
+            embedded_time::duration::Milliseconds(500),
+        ))
+        .unwrap();
+    let mut node = Node::<_, Can, StdClock>::new(Some(42), session_manager);
 
     let sock = CANSocket::open("vcan0").unwrap();
 
-    let mut last_publish = std::time::Instant::now();
+    let mut last_publish = clock.try_now().unwrap();
     let mut transfer_id: TransferId = 30;
 
-    sock.set_read_timeout(core::time::Duration::from_millis(100)).unwrap();
+    sock.set_read_timeout(std::time::Duration::from_millis(100))
+        .unwrap();
 
     loop {
         let socketcan_frame = sock.read_frame().ok();
 
         if let Some(socketcan_frame) = socketcan_frame {
-
             // Note that this exposes some things I *don't* like about the API
             // 1: we should have CanFrame::new or something
             // 2: I don't like how the payload is working
             let mut uavcan_frame = UavcanFrame {
-                timestamp: std::time::Instant::now(),
+                timestamp: clock.try_now().unwrap(),
                 id: socketcan_frame.id(),
                 payload: ArrayVec::new(),
             };
-            uavcan_frame.payload.extend(socketcan_frame.data().iter().copied());
+            uavcan_frame
+                .payload
+                .extend(socketcan_frame.data().iter().copied());
 
             let xfer = match node.try_receive_frame(uavcan_frame) {
                 Ok(xfer) => xfer,
@@ -72,14 +81,16 @@ fn main() {
             }
         }
 
-        if std::time::Instant::now() - last_publish > std::time::Duration::from_millis(500) {
+        if clock.try_now().unwrap() - last_publish
+            > embedded_time::duration::Generic::new(500, StdClock::SCALING_FACTOR)
+        {
             // Publish string
             let hello = "Hello Python!";
             let mut str = Vec::from([hello.len() as u8, 0]);
             str.extend_from_slice(hello.as_bytes());
 
             let transfer = Transfer {
-                timestamp: std::time::Instant::now(),
+                timestamp: clock.try_now().unwrap(),
                 priority: Priority::Nominal,
                 transfer_kind: TransferKind::Message,
                 port_id: 100,
@@ -93,7 +104,8 @@ fn main() {
             transfer_id = (std::num::Wrapping(transfer_id) + std::num::Wrapping(1)).0;
 
             for frame in node.transmit(&transfer).unwrap() {
-                sock.write_frame(&CANFrame::new(frame.id, &frame.payload, false, false).unwrap()).unwrap();
+                sock.write_frame(&CANFrame::new(frame.id, &frame.payload, false, false).unwrap())
+                    .unwrap();
 
                 //print!("Can frame {}: ", i);
                 //for byte in &frame.payload {
@@ -106,8 +118,7 @@ fn main() {
                 //}
             }
 
-            last_publish = std::time::Instant::now();
+            last_publish = clock.try_now().unwrap();
         }
-
     }
 }

--- a/uavcan/Cargo.toml
+++ b/uavcan/Cargo.toml
@@ -23,6 +23,11 @@ bitfield = "0.13"
 crc-any = "2.3.5"
 arrayvec = "0.5.2"
 
+embedded-time = "0.12.0"
+
+[dev-dependencies]
+mock_instant = { version = "0.2", features = ["sync"] }
+
 [features]
 default = ["std"]
 std = []

--- a/uavcan/src/internal.rs
+++ b/uavcan/src/internal.rs
@@ -8,9 +8,9 @@ use crate::Priority;
 /// Internal representation of a received frame.
 ///
 /// This is public so externally-defined SessionManagers can use it.
-#[derive(Copy, Clone, Debug)]
-pub struct InternalRxFrame<'a> {
-    pub timestamp: Timestamp,
+#[derive(Debug)]
+pub struct InternalRxFrame<'a, C: embedded_time::Clock> {
+    pub timestamp: Timestamp<C>,
     pub priority: Priority,
     pub transfer_kind: TransferKind,
     pub port_id: PortId,
@@ -23,10 +23,10 @@ pub struct InternalRxFrame<'a> {
     pub payload: &'a [u8],
 }
 
-impl<'a> InternalRxFrame<'a> {
+impl<'a, C: embedded_time::Clock> InternalRxFrame<'a, C> {
     /// Construct internal frame as a message type
     pub fn as_message(
-        timestamp: Timestamp,
+        timestamp: Timestamp<C>,
         priority: Priority,
         subject_id: PortId,
         source_node_id: Option<NodeId>,
@@ -52,7 +52,7 @@ impl<'a> InternalRxFrame<'a> {
 
     /// Construct internal frame as a service type
     pub fn as_service(
-        timestamp: Timestamp,
+        timestamp: Timestamp<C>,
         priority: Priority,
         transfer_kind: TransferKind,
         service_id: PortId,

--- a/uavcan/src/lib.rs
+++ b/uavcan/src/lib.rs
@@ -32,10 +32,13 @@ extern crate std;
 #[macro_use]
 extern crate num_derive;
 
+pub mod time;
+
 pub mod transfer;
 pub mod transport;
 pub mod types;
 
+use embedded_time::fixed_point::FixedPoint;
 pub use node::Node;
 pub use transfer::TransferKind;
 
@@ -97,20 +100,15 @@ pub enum Priority {
 }
 
 /// Simple subscription type to
-pub struct Subscription {
+pub struct Subscription<D: embedded_time::duration::Duration + FixedPoint> {
     transfer_kind: TransferKind,
     port_id: PortId,
     extent: usize,
-    timeout: core::time::Duration,
+    timeout: D,
 }
 
-impl Subscription {
-    pub fn new(
-        transfer_kind: TransferKind,
-        port_id: PortId,
-        extent: usize,
-        timeout: core::time::Duration,
-    ) -> Self {
+impl<D: embedded_time::duration::Duration + FixedPoint> Subscription<D> {
+    pub fn new(transfer_kind: TransferKind, port_id: PortId, extent: usize, timeout: D) -> Self {
         Self {
             transfer_kind,
             port_id,
@@ -120,7 +118,7 @@ impl Subscription {
     }
 }
 
-impl PartialEq for Subscription {
+impl<D: embedded_time::duration::Duration + FixedPoint> PartialEq for Subscription<D> {
     fn eq(&self, other: &Self) -> bool {
         return self.transfer_kind == other.transfer_kind && self.port_id == other.port_id;
     }

--- a/uavcan/src/session/mod.rs
+++ b/uavcan/src/session/mod.rs
@@ -17,6 +17,8 @@ mod std_vec;
 #[cfg(feature = "std")]
 pub use std_vec::StdVecSessionManager;
 
+use embedded_time::fixed_point::FixedPoint;
+
 /// Session-related errors, caused by reception errors.
 #[derive(Copy, Clone, Debug)]
 pub enum SessionError {
@@ -45,18 +47,21 @@ pub enum SubscriptionError {
 /// select different models based on e.g. your memory allocation strategy,
 /// or if a model provided by this crate does not suffice, you can implement
 /// your own.
-pub trait SessionManager {
+pub trait SessionManager<C: embedded_time::Clock> {
     /// Process incoming frame.
-    fn ingest(&mut self, frame: InternalRxFrame) -> Result<Option<Transfer>, SessionError>;
+    fn ingest(&mut self, frame: InternalRxFrame<C>) -> Result<Option<Transfer<C>>, SessionError>;
 
     /// Housekeeping function called to clean up timed-out sessions.
-    fn update_sessions(&mut self, timestamp: Timestamp);
+    fn update_sessions(&mut self, timestamp: Timestamp<C>);
 
     /// Helper function to match frames to the correct subscription.
     ///
     /// It's not necessary to use this in your implementation, you may have
     /// a more efficient way to check, but this is a spec-compliant function.
-    fn matches_sub(subscription: &crate::Subscription, frame: &InternalRxFrame) -> bool {
+    fn matches_sub<D: embedded_time::duration::Duration + FixedPoint>(
+        subscription: &crate::Subscription<D>,
+        frame: &InternalRxFrame<C>,
+    ) -> bool {
         // Order is chosen to short circuit the most common inconsistencies.
         if frame.port_id != subscription.port_id {
             return false;
@@ -67,4 +72,22 @@ pub trait SessionManager {
 
         return true;
     }
+}
+
+fn timestamp_expired<C: embedded_time::Clock, D>(
+    timeout: D,
+    now: Timestamp<C>,
+    then: Option<Timestamp<C>>,
+) -> bool
+where
+    D: embedded_time::duration::Duration + FixedPoint,
+    <C as embedded_time::Clock>::T: From<<D as FixedPoint>::T>,
+{
+    if let Some(then) = then {
+        if now - then > timeout.to_generic(C::SCALING_FACTOR).unwrap() {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/uavcan/src/session/std_vec.rs
+++ b/uavcan/src/session/std_vec.rs
@@ -3,7 +3,10 @@
 //! This is intended to be the lowest-friction interface to get
 //! started, both for library development and eventually for using the library.
 
+use embedded_time::fixed_point::FixedPoint;
+
 use crate::session::*;
+use crate::time::StdClock;
 use crate::types::NodeId;
 
 use std::collections::HashMap;
@@ -11,16 +14,16 @@ use std::vec::Vec;
 
 /// Internal session object.
 #[derive(Clone, Debug)]
-struct Session<T: crate::transport::SessionMetadata> {
+struct Session<T: crate::transport::SessionMetadata<StdClock>> {
     // Timestamp of first frame
-    pub timestamp: Option<Timestamp>,
+    pub timestamp: Option<Timestamp<StdClock>>,
     pub payload: Vec<u8>,
     pub transfer_id: TransferId,
 
     pub md: T,
 }
 
-impl<T: crate::transport::SessionMetadata> Session<T> {
+impl<T: crate::transport::SessionMetadata<StdClock>> Session<T> {
     pub fn new(transfer_id: TransferId) -> Self {
         Self {
             timestamp: None,
@@ -32,27 +35,20 @@ impl<T: crate::transport::SessionMetadata> Session<T> {
 }
 
 /// Internal subscription object. Contains hash map of sessions.
-struct Subscription<T: crate::transport::SessionMetadata> {
-    sub: crate::Subscription,
+struct Subscription<
+    T: crate::transport::SessionMetadata<StdClock>,
+    D: embedded_time::duration::Duration + FixedPoint,
+> {
+    sub: crate::Subscription<D>,
     sessions: HashMap<NodeId, Session<T>>,
 }
 
-fn timestamp_expired(
-    timeout: core::time::Duration,
-    now: Timestamp,
-    then: Option<Timestamp>,
-) -> bool {
-    if let Some(then) = then {
-        if now - then > timeout {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-impl<T: crate::transport::SessionMetadata> Subscription<T> {
-    pub fn new(sub: crate::Subscription) -> Self {
+impl<T: crate::transport::SessionMetadata<StdClock>, D> Subscription<T, D>
+where
+    D: embedded_time::duration::Duration + FixedPoint,
+    <StdClock as embedded_time::Clock>::T: From<<D as FixedPoint>::T>,
+{
+    pub fn new(sub: crate::Subscription<D>) -> Self {
         Self {
             sub,
             sessions: HashMap::new(),
@@ -60,7 +56,10 @@ impl<T: crate::transport::SessionMetadata> Subscription<T> {
     }
 
     /// Update subscription with incoming frame
-    fn update(&mut self, frame: InternalRxFrame) -> Result<Option<Transfer>, SessionError> {
+    fn update(
+        &mut self,
+        frame: InternalRxFrame<StdClock>,
+    ) -> Result<Option<Transfer<StdClock>>, SessionError> {
         // TODO maybe some of the logic here can be skipped with anon transfers.
         let session = frame.source_node_id.unwrap();
         // Create default session if it doesn't exist
@@ -98,8 +97,8 @@ impl<T: crate::transport::SessionMetadata> Subscription<T> {
     fn accept_frame(
         &mut self,
         session: NodeId,
-        frame: InternalRxFrame,
-    ) -> Result<Option<Transfer>, SessionError> {
+        frame: InternalRxFrame<StdClock>,
+    ) -> Result<Option<Transfer<StdClock>>, SessionError> {
         let mut session = self.sessions.get_mut(&session).unwrap();
 
         if frame.start_of_transfer {
@@ -137,11 +136,18 @@ impl<T: crate::transport::SessionMetadata> Subscription<T> {
 /// SessionManager based on full std support. Meant to be lowest
 /// barrier to entry and greatest flexibility at the cost of resource usage
 /// and not being no_std.
-pub struct StdVecSessionManager<T: crate::transport::SessionMetadata> {
-    subscriptions: Vec<Subscription<T>>,
+pub struct StdVecSessionManager<
+    T: crate::transport::SessionMetadata<StdClock>,
+    D: embedded_time::duration::Duration + FixedPoint,
+> {
+    subscriptions: Vec<Subscription<T, D>>,
 }
 
-impl<T: crate::transport::SessionMetadata> StdVecSessionManager<T> {
+impl<T: crate::transport::SessionMetadata<StdClock>, D> StdVecSessionManager<T, D>
+where
+    D: embedded_time::duration::Duration + FixedPoint,
+    <StdClock as embedded_time::Clock>::T: From<<D as FixedPoint>::T>,
+{
     pub fn new() -> Self {
         Self {
             subscriptions: Vec::new(),
@@ -151,7 +157,7 @@ impl<T: crate::transport::SessionMetadata> StdVecSessionManager<T> {
     /// Add a subscription
     pub fn subscribe(
         &mut self,
-        subscription: crate::Subscription,
+        subscription: crate::Subscription<D>,
     ) -> Result<(), SubscriptionError> {
         if self.subscriptions.iter().any(|s| s.sub == subscription) {
             return Err(SubscriptionError::SubscriptionExists);
@@ -164,7 +170,7 @@ impl<T: crate::transport::SessionMetadata> StdVecSessionManager<T> {
     /// Modify subscription in place, creating a new one if not found.
     pub fn edit_subscription(
         &mut self,
-        subscription: crate::Subscription,
+        subscription: crate::Subscription<D>,
     ) -> Result<(), SubscriptionError> {
         match self
             .subscriptions
@@ -182,7 +188,7 @@ impl<T: crate::transport::SessionMetadata> StdVecSessionManager<T> {
     /// Removes a subscription from the list.
     pub fn unsubscribe(
         &mut self,
-        subscription: crate::Subscription,
+        subscription: crate::Subscription<D>,
     ) -> Result<(), SubscriptionError> {
         match self
             .subscriptions
@@ -198,8 +204,16 @@ impl<T: crate::transport::SessionMetadata> StdVecSessionManager<T> {
     }
 }
 
-impl<T: crate::transport::SessionMetadata> SessionManager for StdVecSessionManager<T> {
-    fn ingest(&mut self, frame: InternalRxFrame) -> Result<Option<Transfer>, SessionError> {
+impl<T: crate::transport::SessionMetadata<StdClock>, D> SessionManager<StdClock>
+    for StdVecSessionManager<T, D>
+where
+    D: embedded_time::duration::Duration + FixedPoint,
+    <StdClock as embedded_time::Clock>::T: From<<D as FixedPoint>::T>,
+{
+    fn ingest(
+        &mut self,
+        frame: InternalRxFrame<StdClock>,
+    ) -> Result<Option<Transfer<StdClock>>, SessionError> {
         match self
             .subscriptions
             .iter_mut()
@@ -210,7 +224,7 @@ impl<T: crate::transport::SessionMetadata> SessionManager for StdVecSessionManag
         }
     }
 
-    fn update_sessions(&mut self, timestamp: Timestamp) {
+    fn update_sessions(&mut self, timestamp: Timestamp<StdClock>) {
         for sub in &mut self.subscriptions {
             for session in sub.sessions.values_mut() {
                 if timestamp_expired(sub.sub.timeout, timestamp, session.timestamp) {

--- a/uavcan/src/time.rs
+++ b/uavcan/src/time.rs
@@ -1,0 +1,238 @@
+#[cfg(test)]
+pub use test_clock::TestClock;
+
+#[cfg(feature = "std")]
+pub use std_clock::StdClock;
+
+#[cfg(test)]
+mod test_clock {
+    use core::{
+        cell::RefCell,
+        fmt::Debug,
+        hash::Hash,
+        ops::{Add, AddAssign, Deref},
+    };
+
+    use std::rc::Rc;
+
+    use embedded_time::{
+        duration::{Duration, Microseconds, Milliseconds},
+        fixed_point::FixedPoint,
+        Clock, ConversionError, TimeInt,
+    };
+
+    /// A Clock for test cases
+    ///
+    /// Contains a intern tick counter and a fraction which is set to 1 / 1,000,000 (secs) = resolution of one microsecond.
+    /// Clock wraps if intern type overflows! (intern type = u32 -> ~71min)
+    #[derive(Debug, Clone)]
+    pub struct TestClock<TickType = u32>(Rc<RefCell<TickType>>)
+    where
+        TickType: TimeInt;
+
+    impl<TickType: TimeInt> TestClock<TickType>
+    where
+        Self: Clock,
+    {
+        /// Add raw ticks to the clock.
+        ///
+        /// In particular 1 tick = 1 microsecond.
+        pub fn add_ticks(&mut self, ticks: TickType) {
+            self.0.deref().borrow_mut().wrapping_add(&ticks);
+        }
+
+        /// Add a duration to the clock.
+        ///
+        /// # Example
+        /// ```
+        /// let clock = TestClock::default();
+        /// clock.add_duration(&Milliseconds::new(1243u32));
+        /// ```
+        pub fn add_duration<D: Duration + FixedPoint>(
+            &mut self,
+            duration: &D,
+        ) -> Result<(), ConversionError>
+        where
+            TickType: From<<D as FixedPoint>::T>,
+        {
+            let mut tick_count = self.0.deref().borrow_mut();
+            *tick_count =
+                tick_count.wrapping_add(&duration.to_generic(Self::SCALING_FACTOR)?.integer());
+            Ok(())
+        }
+
+        /// Get a clone of the clock which points to the same tick count.
+        // like alloc::borrow::ToOwned but don't want to use alloc crate by now
+        pub fn to_owned(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    impl Default for TestClock<u32> {
+        fn default() -> Self {
+            Self(Rc::new(RefCell::new(u32::default())))
+        }
+    }
+
+    impl<TickType: TimeInt + Hash + Add + AddAssign> Clock for TestClock<TickType> {
+        type T = TickType;
+
+        const SCALING_FACTOR: embedded_time::rate::Fraction =
+            embedded_time::rate::Fraction::new(1, 1_000_000);
+
+        fn try_now(&self) -> Result<embedded_time::Instant<Self>, embedded_time::clock::Error> {
+            Ok(embedded_time::Instant::new(*self.0.borrow()))
+        }
+    }
+
+    #[test]
+    fn test_fraction_as_1_tick_1_micros() {
+        let mut clock = TestClock::default();
+        clock.add_ticks(1);
+
+        assert_eq!(
+            clock.try_now().unwrap().duration_since_epoch(),
+            Microseconds::new(1u32)
+                .to_generic::<u32>(TestClock::<u32>::SCALING_FACTOR)
+                .unwrap(),
+            "1 tick does not equal to 1 microsecond"
+        )
+    }
+
+    #[test]
+    fn test_add_duration() {
+        let mut clock = TestClock::default();
+        let millis = Milliseconds::new(1243u32);
+        assert!(
+            clock.add_duration(&millis).is_ok(),
+            "error on incrementing clock"
+        );
+        assert_eq!(
+            clock.try_now().unwrap().duration_since_epoch(),
+            millis
+                .to_generic::<u32>(TestClock::<u32>::SCALING_FACTOR)
+                .unwrap(),
+            "clock not at same time"
+        )
+    }
+
+    #[test]
+    fn test_increment_clock_with_clones() {
+        let mut clock = TestClock::default();
+        let clock_clone = clock.to_owned();
+
+        let millis = Milliseconds::new(1243u32);
+        assert!(
+            clock.add_duration(&millis).is_ok(),
+            "error on incrementing clock"
+        );
+        assert!(
+            clock.try_now().unwrap().duration_since_epoch().eq(&millis
+                .to_generic::<u32>(TestClock::<u32>::SCALING_FACTOR)
+                .unwrap()),
+            "clock not at same time"
+        );
+        assert_eq!(
+            clock.try_now().unwrap(),
+            clock_clone.try_now().unwrap(),
+            "clocks not at same time"
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+mod std_clock {
+    use core::{cell::RefCell, convert::TryInto};
+
+    use std::rc::Rc;
+
+    #[cfg(test)]
+    use mock_instant::Instant;
+    #[cfg(not(test))]
+    use std::time::Instant;
+
+    /// A clock to use in std environments.
+    ///
+    /// Safes the actual time instance at creation. Returns for every call `to StdClock::try_now()`
+    /// the relative time to creation time.
+    /// This design is used, because it should only give relative time points and not exact world
+    /// time points. In addition, to set the representing type to `u64` and to give a microsecond
+    /// resolution, the clock can run longer without overflow.
+    ///
+    /// # Example
+    /// ```ignore
+    /// let clock = StdClock::new();
+    /// assert!(
+    ///    clock.try_now().unwrap().duration_since_epoch() >
+    ///    Microseconds::new(0u32)
+    ///        .to_generic(StdClock::SCALING_FACTOR)
+    ///        .unwrap()
+    /// );
+    /// ```
+    #[derive(Clone, Debug)]
+    pub struct StdClock(Rc<RefCell<Instant>>);
+
+    impl StdClock {
+        /// Creates a new `StdClock` with an offset of the actual `std::time::Instant`.
+        ///
+        /// The clock is zeroed at this time point.  
+        pub fn new() -> Self {
+            Self(Rc::new(RefCell::new(Instant::now())))
+        }
+    }
+
+    impl embedded_time::Clock for StdClock {
+        type T = u64;
+
+        const SCALING_FACTOR: embedded_time::rate::Fraction =
+            embedded_time::rate::Fraction::new(1, 1_000_000);
+
+        fn try_now(&self) -> Result<embedded_time::Instant<Self>, embedded_time::clock::Error> {
+            let now = Instant::now() - *self.0.borrow();
+            let time_passed: u64 = now
+                .as_micros()
+                .try_into()
+                .map_err(|_| embedded_time::clock::Error::Unspecified)?;
+
+            Ok(embedded_time::Instant::new(time_passed))
+        }
+    }
+
+    #[cfg(test)]
+    mod test {
+        use embedded_time::{
+            duration::{Duration, Microseconds},
+            Clock,
+        };
+        use mock_instant::MockClock;
+
+        use super::StdClock;
+
+        #[test]
+        fn test_clock() {
+            // set instant to random start
+            MockClock::advance(core::time::Duration::from_micros(23425));
+
+            let clock = StdClock::new();
+            let advance_micros = 1000u64;
+
+            assert_eq!(
+                clock.try_now().unwrap().duration_since_epoch(),
+                Microseconds::new(0u32)
+                    .to_generic(StdClock::SCALING_FACTOR)
+                    .unwrap(),
+                "clock is not zero at beginning"
+            );
+
+            MockClock::advance(core::time::Duration::from_micros(advance_micros));
+
+            assert_eq!(
+                clock.try_now().unwrap().duration_since_epoch(),
+                Microseconds::new(advance_micros)
+                    .to_generic(StdClock::SCALING_FACTOR)
+                    .unwrap(),
+                "clock gives not correct time"
+            );
+        }
+    }
+}

--- a/uavcan/src/transfer.rs
+++ b/uavcan/src/transfer.rs
@@ -18,9 +18,10 @@ pub enum TransferKind {
 ///
 /// This will be passed out on successful reception of full transfers,
 /// as well as given to objects to encode into the correct transport.
-#[derive(Clone, Debug)]
-pub struct Transfer<'a> {
-    pub timestamp: Timestamp,
+#[derive(Debug)]
+pub struct Transfer<'a, C: embedded_time::Clock> {
+    // for tx -> transmission_timeout
+    pub timestamp: Timestamp<C>,
     pub priority: Priority,
     pub transfer_kind: TransferKind,
     pub port_id: PortId,
@@ -30,8 +31,12 @@ pub struct Transfer<'a> {
 }
 
 // I don't want to impl convert::From because I need to pull in extra data
-impl<'a> Transfer<'a> {
-    pub fn from_frame(frame: InternalRxFrame, timestamp: Timestamp, payload: &'a [u8]) -> Self {
+impl<'a, C: embedded_time::Clock> Transfer<'a, C> {
+    pub fn from_frame(
+        frame: InternalRxFrame<C>,
+        timestamp: Timestamp<C>,
+        payload: &'a [u8],
+    ) -> Self {
         Self {
             timestamp: timestamp,
             priority: frame.priority,

--- a/uavcan/src/transport/can/mod.rs
+++ b/uavcan/src/transport/can/mod.rs
@@ -10,6 +10,7 @@
 //! for quite a while... :(.
 
 use arrayvec::ArrayVec;
+use embedded_time::Clock;
 use num_traits::{FromPrimitive, ToPrimitive};
 
 use crate::Priority;
@@ -34,14 +35,14 @@ pub const MTU_SIZE: usize = 8;
 #[derive(Copy, Clone, Debug)]
 pub struct Can;
 
-impl Transport for Can {
-    type Frame = CanFrame;
-    type FrameIter<'a> = CanIter<'a>;
+impl<C: embedded_time::Clock + 'static> Transport<C> for Can {
+    type Frame = CanFrame<C>;
+    type FrameIter<'a> = CanIter<'a, C>;
 
     fn rx_process_frame<'a>(
         node_id: &Option<NodeId>,
         frame: &'a Self::Frame,
-    ) -> Result<Option<InternalRxFrame<'a>>, RxError> {
+    ) -> Result<Option<InternalRxFrame<'a, C>>, RxError> {
         // Frames cannot be empty. They must at least have a tail byte.
         // NOTE: libcanard specifies this as only for multi-frame transfers but uses
         // this logic.
@@ -126,7 +127,9 @@ impl Transport for Can {
         }
     }
 
-    fn transmit<'a>(transfer: &'a crate::transfer::Transfer) -> Result<Self::FrameIter<'a>, TxError> {
+    fn transmit<'a>(
+        transfer: &'a crate::transfer::Transfer<C>,
+    ) -> Result<Self::FrameIter<'a>, TxError> {
         CanIter::new(transfer, Some(1))
     }
 }
@@ -137,8 +140,8 @@ impl Transport for Can {
 /// array, store it in another object, or just bulk transfer it all at once, without
 /// having to commit to any proper memory model.
 #[derive(Debug)]
-pub struct CanIter<'a> {
-    transfer: &'a crate::transfer::Transfer<'a>,
+pub struct CanIter<'a, C: embedded_time::Clock> {
+    transfer: &'a crate::transfer::Transfer<'a, C>,
     frame_id: u32,
     payload_offset: usize,
     crc: crc_any::CRCu16,
@@ -147,9 +150,9 @@ pub struct CanIter<'a> {
     is_start: bool,
 }
 
-impl<'a> CanIter<'a> {
+impl<'a, C: embedded_time::Clock> CanIter<'a, C> {
     fn new(
-        transfer: &'a crate::transfer::Transfer,
+        transfer: &'a crate::transfer::Transfer<C>,
         node_id: Option<NodeId>,
     ) -> Result<Self, TxError> {
         let frame_id = match transfer.transfer_kind {
@@ -208,13 +211,13 @@ impl<'a> CanIter<'a> {
     }
 }
 
-impl<'a> Iterator for CanIter<'a> {
-    type Item = CanFrame;
+impl<'a, C: Clock> Iterator for CanIter<'a, C> {
+    type Item = CanFrame<C>;
 
     // I'm sure I could take an optimization pass at the logic here
     fn next(&mut self) -> Option<Self::Item> {
         let mut frame = CanFrame {
-            timestamp: std::time::Instant::now(),
+            timestamp: self.transfer.timestamp,
             id: self.frame_id,
             payload: ArrayVec::new(),
         };
@@ -320,8 +323,8 @@ impl<'a> Iterator for CanIter<'a> {
 // TODO convert to embedded-hal PR type
 /// Extended CAN frame (the only one supported by UAVCAN/CAN)
 #[derive(Clone, Debug)]
-pub struct CanFrame {
-    pub timestamp: Timestamp,
+pub struct CanFrame<C: embedded_time::Clock> {
+    pub timestamp: Timestamp<C>,
     pub id: u32,
     pub payload: ArrayVec<[u8; 8]>,
 }
@@ -333,7 +336,7 @@ pub struct CanMetadata {
     crc: crc_any::CRCu16,
 }
 
-impl super::SessionMetadata for CanMetadata {
+impl<C: embedded_time::Clock> super::SessionMetadata<C> for CanMetadata {
     fn new() -> Self {
         Self {
             // Toggle starts off true, but we compare against the opposite value.
@@ -342,7 +345,7 @@ impl super::SessionMetadata for CanMetadata {
         }
     }
 
-    fn update(&mut self, frame: &crate::internal::InternalRxFrame) -> Option<usize> {
+    fn update(&mut self, frame: &crate::internal::InternalRxFrame<C>) -> Option<usize> {
         // Single frame transfers don't need to be validated
         if frame.start_of_transfer && frame.end_of_transfer {
             // Still need to truncate tail byte
@@ -368,7 +371,7 @@ impl super::SessionMetadata for CanMetadata {
         }
     }
 
-    fn is_valid(&self, frame: &crate::internal::InternalRxFrame) -> bool {
+    fn is_valid(&self, frame: &crate::internal::InternalRxFrame<C>) -> bool {
         if frame.start_of_transfer && frame.end_of_transfer {
             return true;
         }

--- a/uavcan/src/transport/mod.rs
+++ b/uavcan/src/transport/mod.rs
@@ -18,22 +18,22 @@ use crate::{RxError, TxError};
 /// In the example of CAN, you need to keep track of the toggle bit,
 /// as well as the CRC for multi-frame transfers. This trait lets us pull that
 /// code out of the generic processing and into more modular implementations.
-pub trait SessionMetadata {
+pub trait SessionMetadata<C: embedded_time::Clock> {
     /// Create a fresh instance of session metadata;
     fn new() -> Self;
 
     /// Update metadata with incoming frame's information.
     ///
     /// If the frame is valid, returns Some(length of payload to ingest)
-    fn update(&mut self, frame: &InternalRxFrame) -> Option<usize>;
+    fn update(&mut self, frame: &InternalRxFrame<C>) -> Option<usize>;
 
     /// Final check to see if transfer was successful.
-    fn is_valid(&self, frame: &InternalRxFrame) -> bool;
+    fn is_valid(&self, frame: &InternalRxFrame<C>) -> bool;
 }
 
 /// This trait is to be implemented on a unit struct, in order to be specified
 /// for different transport types.
-pub trait Transport {
+pub trait Transport<C: embedded_time::Clock> {
     type Frame;
     type FrameIter<'a>: Iterator;
 
@@ -42,8 +42,10 @@ pub trait Transport {
     fn rx_process_frame<'a>(
         node_id: &Option<NodeId>,
         frame: &'a Self::Frame,
-    ) -> Result<Option<InternalRxFrame<'a>>, RxError>;
+    ) -> Result<Option<InternalRxFrame<'a, C>>, RxError>;
 
     /// Prepare an iterator of frames to send out on the wire.
-    fn transmit<'a>(transfer: &'a crate::transfer::Transfer) -> Result<Self::FrameIter<'a>, TxError>;
+    fn transmit<'a>(
+        transfer: &'a crate::transfer::Transfer<C>,
+    ) -> Result<Self::FrameIter<'a>, TxError>;
 }

--- a/uavcan/src/types.rs
+++ b/uavcan/src/types.rs
@@ -14,4 +14,4 @@ pub type PortId = u16;
 pub type TransferId = u8;
 
 // TODO whole timing overhaul
-pub type Timestamp = std::time::Instant;
+pub type Timestamp<C> = embedded_time::Instant<C>;


### PR DESCRIPTION
The new time implementation uses the crate [embedded_time](https://docs.rs/embedded-time/0.12.1/embedded_time/).

Now, at the beginning a Clock must be defined. For a std environment, a StdClock is provided to use std::time::Instanst::now(). But it does not give the exact time. It returns the time relative to the program start. This is not a big deal because we only need relative timestamps in the crate. If we think of an embedded device, this is the normal case.

For tests, a TestClock is provided to test the library based on it. This clock can be fast forwarded to simulate a later time point for testing.

The functionality of these two clocks is tested with tests:)

This implementation gives an overhead because every timestamp and duration needs a generic of the used clock to get the fraction of it. To learn more of the idea of the embedded_time crate, read in its documentation.

All tests passing:
```
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```