### PR TITLE
use streamiterator instead of std iterator

### DIFF
--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -13,6 +13,7 @@ embedded-time = "0.12.0"
 
 # TODO: if new embedded-hal version releases, this can be changed to crates.io
 embedded-hal = {version = "0.2.6", git = "https://github.com/rust-embedded/embedded-hal/", branch = "v0.2.x"}
+streaming-iterator = "0.1.5"
 
 [dependencies.uavcan]
 path = "../../uavcan"

--- a/uavcan/Cargo.toml
+++ b/uavcan/Cargo.toml
@@ -23,6 +23,7 @@ bitfield = "0.13"
 # TODO: if new embedded-hal version releases, this can be changed to crates.io
 embedded-hal = {version = "0.2.6", git = "https://github.com/rust-embedded/embedded-hal/", branch = "v0.2.x"}
 embedded-time = "0.12.0"
+streaming-iterator = "0.1.5"
 
 # should only in no_std, so if feature std not set - ref: https://github.com/rust-lang/cargo/issues/1839
 heapless = "0.7.7"

--- a/uavcan/Cargo.toml
+++ b/uavcan/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uavcan"
 authors = ["David Lenfesty <lenfesty@ualberta.ca>"]
 version = "0.2.0-preview0"
-edition = "2018"
+edition = "2021"
 
 description = "Full functionality reference implementation of UAVCAN/CAN in Rust"
 

--- a/uavcan/src/transport/can/mod.rs
+++ b/uavcan/src/transport/can/mod.rs
@@ -235,7 +235,7 @@ impl<'a, C: Clock> StreamingIterator for CanIter<'a, C> {
         // TODO enough to use the transfer timestamp, or need actual timestamp
         let frame = self
             .can_frame
-            .get_or_insert_with(|| CanFrame::new(self.transfer.timestamp, self.frame_id));
+            .get_or_insert_with(|| CanFrame::new(self.transfer.timestamp, self.frame_id.as_raw()));
 
         frame.payload.clear();
 
@@ -338,7 +338,8 @@ impl<C: embedded_time::Clock> CanFrame<C> {
     fn new(timestamp: Timestamp<C>, id: u32) -> Self {
         Self {
             timestamp,
-            id,
+            // TODO get rid of this expect, it probably isn't necessary, just added quickly
+            id: ExtendedId::new(id).expect("invalid ID"),
             payload: ArrayVec::<[u8; 8]>::new(),
         }
     }

--- a/uavcan/src/transport/can/mod.rs
+++ b/uavcan/src/transport/can/mod.rs
@@ -13,6 +13,7 @@ use arrayvec::ArrayVec;
 use embedded_hal::can::ExtendedId;
 use embedded_time::Clock;
 use num_traits::FromPrimitive;
+use streaming_iterator::StreamingIterator;
 
 use crate::time::Timestamp;
 use crate::Priority;
@@ -152,6 +153,7 @@ pub struct CanIter<'a, C: embedded_time::Clock> {
     crc: Crc16,
     toggle: bool,
     is_start: bool,
+    can_frame: Option<CanFrame<C>>,
 }
 
 impl<'a, C: embedded_time::Clock> CanIter<'a, C> {
@@ -205,25 +207,37 @@ impl<'a, C: embedded_time::Clock> CanIter<'a, C> {
             crc: Crc16::init(),
             toggle: true,
             is_start: true,
+            can_frame: None,
         })
     }
 }
 
-impl<'a, C: Clock> Iterator for CanIter<'a, C> {
+impl<'a, C: Clock> StreamingIterator for CanIter<'a, C> {
     type Item = CanFrame<C>;
 
-    // I'm sure I could take an optimization pass at the logic here
-    fn next(&mut self) -> Option<Self::Item> {
-        let mut frame = CanFrame {
-            // TODO enough to use the transfer timestamp, or need actual timestamp
-            timestamp: self.transfer.timestamp,
-            id: self.frame_id,
-            payload: ArrayVec::new(),
-        };
+    fn get(&self) -> Option<&Self::Item> {
+        self.can_frame.as_ref()
+    }
 
+    // I'm sure I could take an optimization pass at the logic here
+    fn advance(&mut self) {
         let bytes_left = self.transfer.payload.len() - self.payload_offset;
+
+        // Nothing left to transmit, we are done
+        if bytes_left == 0 && self.crc_left == 0 {
+            let _ = self.can_frame.take();
+            return;
+        }
+
         let is_end = bytes_left <= 7;
         let copy_len = core::cmp::min(bytes_left, 7);
+
+        // TODO enough to use the transfer timestamp, or need actual timestamp
+        let frame = self
+            .can_frame
+            .get_or_insert_with(|| CanFrame::new(self.transfer.timestamp, self.frame_id));
+
+        frame.payload.clear();
 
         if self.is_start && is_end {
             // Single frame transfer, no CRC
@@ -231,22 +245,18 @@ impl<'a, C: Clock> Iterator for CanIter<'a, C> {
                 .payload
                 .extend(self.transfer.payload[0..copy_len].iter().copied());
             self.payload_offset += bytes_left;
+            self.crc_left = 0;
             unsafe {
                 frame.payload.push_unchecked(
                     TailByte::new(true, true, true, self.transfer.transfer_id).0
                 )
             }
         } else {
-            // Nothing left to transmit, we are done
-            if bytes_left == 0 && self.crc_left == 0 {
-                return None;
-            }
-
             // Handle CRC
             let out_data =
                 &self.transfer.payload[self.payload_offset..self.payload_offset + copy_len];
             self.crc.digest(out_data);
-            frame.payload.extend(out_data.iter().copied());
+            frame.payload.extend(out_data.into_iter().copied());
 
             // Increment offset
             self.payload_offset += copy_len;
@@ -261,8 +271,7 @@ impl<'a, C: Clock> Iterator for CanIter<'a, C> {
                     if 7 - bytes_left >= 2 {
                         // Iter doesn't work. Internal type is &u8 but extend
                         // expects u8
-                        frame.payload.push(crc[0]);
-                        frame.payload.push(crc[1]);
+                        frame.payload.extend(crc.into_iter());
                         self.crc_left = 0;
                     } else {
                         // SAFETY: only written if we have enough space
@@ -295,8 +304,6 @@ impl<'a, C: Clock> Iterator for CanIter<'a, C> {
         }
 
         self.is_start = false;
-
-        Some(frame)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -325,6 +332,16 @@ pub struct CanFrame<C: embedded_time::Clock> {
     pub timestamp: Timestamp<C>,
     pub id: ExtendedId,
     pub payload: ArrayVec<[u8; 8]>,
+}
+
+impl<C: embedded_time::Clock> CanFrame<C> {
+    fn new(timestamp: Timestamp<C>, id: u32) -> Self {
+        Self {
+            timestamp,
+            id,
+            payload: ArrayVec::<[u8; 8]>::new(),
+        }
+    }
 }
 
 /// Keeps track of toggle bit and CRC during frame processing.

--- a/uavcan/src/transport/can/tests.rs
+++ b/uavcan/src/transport/can/tests.rs
@@ -33,7 +33,7 @@ fn receive_anon_frame() {
     let mut frame = CanFrame {
         timestamp: clock.try_now().unwrap(),
         id: CanMessageId::new(Priority::Nominal, 0, None),
-        payload: ArrayVec::new(),
+        payload: arrayvec::ArrayVec::<[u8; 8]>::new(),
     };
 
     frame.payload.extend(0..5);
@@ -53,7 +53,7 @@ fn receive_message_frame() {
     let mut frame = CanFrame {
         timestamp: clock.try_now().unwrap(),
         id: CanMessageId::new(Priority::Nominal, 0, Some(41)),
-        payload: ArrayVec::new(),
+        payload: arrayvec::ArrayVec::<[u8; 8]>::new(),
     };
 
     frame.payload.push(TailByte::new(true, true, true, 0).0);
@@ -71,7 +71,7 @@ fn receive_service_frame() {
     let mut frame = CanFrame {
         timestamp: clock.try_now().unwrap(),
         id: CanServiceId::new(Priority::Nominal, false, 0, 42, 41),
-        payload: ArrayVec::new(),
+        payload: arrayvec::ArrayVec::<[u8; 8]>::new(),
     };
 
     frame.payload.push(TailByte::new(true, true, true, 0).0);
@@ -112,7 +112,7 @@ fn discard_anon_multi_frame() {
     let mut frame = CanFrame {
         timestamp: clock.try_now().unwrap(),
         id: CanMessageId::new(Priority::Nominal, 0, None),
-        payload: ArrayVec::new(),
+        payload: arrayvec::ArrayVec::<[u8; 8]>::new(),
     };
 
     // Need to fill frame to avoid tail_byte_checks() cases
@@ -141,7 +141,7 @@ fn discard_misguided_service_frames() {
     let mut frame = CanFrame {
         timestamp: clock.try_now().unwrap(),
         id: CanServiceId::new(Priority::Nominal, true, 0, 31, 41),
-        payload: ArrayVec::new(),
+        payload: arrayvec::ArrayVec::<[u8; 8]>::new(),
     };
 
     // Request
@@ -186,7 +186,7 @@ fn tail_byte_checks() {
     let mut frame = CanFrame {
         timestamp: clock.try_now().unwrap(),
         id: CanMessageId::new(Priority::Nominal, 0, None),
-        payload: ArrayVec::new(),
+        payload: arrayvec::ArrayVec::<[u8; 8]>::new(),
     };
 
     frame.payload.push(TailByte::new(true, true, false, 0).0);
@@ -230,20 +230,18 @@ fn transfer_valid_ids() {
     // but this is the most ergonomic entry point for this test.
 
     // Anonymous message
-    let frame: CanFrame<TestClock<u32>> = CanIter::new(&transfer, None)
-        .unwrap()
-        .next()
-        .expect("Failed to create iter");
-    let id = CanMessageId::from(frame.id);
+    let mut can_iter = CanIter::new(&transfer, None).unwrap();
+    let frame: &CanFrame<TestClock<u32>> = can_iter.next().expect("Failed to create iter");
+    let id = CanMessageId(frame.id);
     assert!(id.is_message());
     assert!(id.is_anon());
     assert!(id.subject_id() == 0);
     assert!(id.priority() == Priority::Nominal as u8);
     // Source ID should be random, not sure how to handle this...
 
-    let frame: CanFrame<TestClock<u32>> =
-        CanIter::new(&transfer, Some(12)).unwrap().next().expect("");
-    let id = CanMessageId::from(frame.id);
+    let mut can_iter = CanIter::new(&transfer, Some(12)).unwrap();
+    let frame: &CanFrame<TestClock<u32>> = can_iter.next().expect("");
+    let id = CanMessageId(frame.id);
     assert!(id.is_message());
     assert!(!id.is_anon());
     assert!(id.subject_id() == 0);
@@ -257,8 +255,8 @@ fn transfer_valid_ids() {
 }
 
 /// Checks that the iterator produces the expected number of frames.
-fn assert_frame_count(iter: CanIter<TestClock>, mut expected: usize) {
-    for _frame in iter {
+fn assert_frame_count(mut iter: CanIter<TestClock>, mut expected: usize) {
+    while let Some(_frame) = iter.next() {
         assert!(expected > 0);
         expected -= 1;
     }

--- a/uavcan/src/transport/can/tests.rs
+++ b/uavcan/src/transport/can/tests.rs
@@ -232,7 +232,7 @@ fn transfer_valid_ids() {
     // Anonymous message
     let mut can_iter = CanIter::new(&transfer, None).unwrap();
     let frame: &CanFrame<TestClock<u32>> = can_iter.next().expect("Failed to create iter");
-    let id = CanMessageId(frame.id);
+    let id = CanMessageId(frame.id.as_raw());
     assert!(id.is_message());
     assert!(id.is_anon());
     assert!(id.subject_id() == 0);
@@ -241,7 +241,7 @@ fn transfer_valid_ids() {
 
     let mut can_iter = CanIter::new(&transfer, Some(12)).unwrap();
     let frame: &CanFrame<TestClock<u32>> = can_iter.next().expect("");
-    let id = CanMessageId(frame.id);
+    let id = CanMessageId(frame.id.as_raw());
     assert!(id.is_message());
     assert!(!id.is_anon());
     assert!(id.subject_id() == 0);

--- a/uavcan/src/transport/mod.rs
+++ b/uavcan/src/transport/mod.rs
@@ -9,6 +9,8 @@
 // Declaring all of the sub transport modules here.
 pub mod can;
 
+use streaming_iterator::StreamingIterator;
+
 use crate::internal::InternalRxFrame;
 use crate::NodeId;
 use crate::{RxError, TxError};
@@ -37,7 +39,7 @@ pub trait Transport<C: embedded_time::Clock> {
     type Frame;
     // TODO does this properly describe the lifetime semantics of this type?
     // I implemented this as a quick fix to get the PR tests going - David
-    type FrameIter<'a>: Iterator where C: 'a;
+    type FrameIter<'a>: StreamingIterator where C: 'a;
 
     /// Process a frame, returning the internal transport-independant representation,
     /// or errors if invalid.


### PR DESCRIPTION
The idea behind this is to avoid creating the `CanFrame`, which is used to transmit the single frames, for every frame. With the `StreamIterator` the frame can be initialized once per transfer and then be reused. 

I did some performance tests on the different implementations for transfers and got these results (cortex-m4 170 MHz, measurements in micros):

|frames|std iterator|streamiterator|
|:----:|---:|---:|
1 | 0 | 0
2 | 3 | 3
3 | 5 | 4
4 | 7 | 6
5 | 8 | 7
6 | 10 | 8
7 | 11 | 10
8 | 12 | 11

This is not that much of a performance improvement. But I think for the future this could be helpful. The now used `ArrayVec` is very efficient in array initialization and is great for the 8 byte which are used by classic CAN.  But if the transmission can send a larger payload, this could give more performance boost. As well, if we have to use a heap allocated payload somehow.

This new implementation will change the usage for transfer messages:

```Rust
let mut frame_iter = node.transmit(&transfer).unwrap();
while let Some(frame) = frame_iter.next() {
    send...
}
```

The user gets the frame as a reference. This has no limitations. If the user needs to store the frame to send somehow later, it could be done by cloning the frame. But now the user is responsible for this.























































