### PR TITLE
change can raw_id (u32) to ExtendedId struct

### DIFF
--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 socketcan = "1.7.0"
 arrayvec = "0.5.2"
 embedded-time = "0.12.0"
+embedded-hal = {version = "0.2.6", git = "https://github.com/rust-embedded/embedded-hal/", branch = "v0.2.x"}
 
 [dependencies.uavcan]
 path = "../../uavcan"

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -10,6 +10,8 @@ edition = "2018"
 socketcan = "1.7.0"
 arrayvec = "0.5.2"
 embedded-time = "0.12.0"
+
+# TODO: if new embedded-hal version releases, this can be changed to crates.io
 embedded-hal = {version = "0.2.6", git = "https://github.com/rust-embedded/embedded-hal/", branch = "v0.2.x"}
 
 [dependencies.uavcan]

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -1,3 +1,4 @@
+use embedded_hal::can::ExtendedId;
 use embedded_time::duration::Milliseconds;
 use embedded_time::Clock;
 use uavcan::session::StdVecSessionManager;
@@ -46,7 +47,7 @@ fn main() {
             // 2: I don't like how the payload is working
             let mut uavcan_frame = UavcanFrame {
                 timestamp: clock.try_now().unwrap(),
-                id: socketcan_frame.id(),
+                id: ExtendedId::new(socketcan_frame.id()).expect("not a extended CAN ID"),
                 payload: ArrayVec::new(),
             };
             uavcan_frame
@@ -104,8 +105,10 @@ fn main() {
             transfer_id = (std::num::Wrapping(transfer_id) + std::num::Wrapping(1)).0;
 
             for frame in node.transmit(&transfer).unwrap() {
-                sock.write_frame(&CANFrame::new(frame.id, &frame.payload, false, false).unwrap())
-                    .unwrap();
+                sock.write_frame(
+                    &CANFrame::new(frame.id.as_raw(), &frame.payload, false, false).unwrap(),
+                )
+                .unwrap();
 
                 //print!("Can frame {}: ", i);
                 //for byte in &frame.payload {

--- a/uavcan/Cargo.toml
+++ b/uavcan/Cargo.toml
@@ -20,6 +20,7 @@ license = "Apache-2.0/MIT"
 num-derive = "0.3"
 bitfield = "0.13"
 
+embedded-hal = {version = "0.2.6", git = "https://github.com/rust-embedded/embedded-hal/", branch = "v0.2.x"}
 embedded-time = "0.12.0"
 
 # should only in no_std, so if feature std not set - ref: https://github.com/rust-lang/cargo/issues/1839

--- a/uavcan/Cargo.toml
+++ b/uavcan/Cargo.toml
@@ -20,6 +20,7 @@ license = "Apache-2.0/MIT"
 num-derive = "0.3"
 bitfield = "0.13"
 
+# TODO: if new embedded-hal version releases, this can be changed to crates.io
 embedded-hal = {version = "0.2.6", git = "https://github.com/rust-embedded/embedded-hal/", branch = "v0.2.x"}
 embedded-time = "0.12.0"
 

--- a/uavcan/src/transport/can/bitfields.rs
+++ b/uavcan/src/transport/can/bitfields.rs
@@ -107,11 +107,7 @@ impl CanServiceId {
         service_id: PortId,
         destination: NodeId,
         source: NodeId,
-<<<<<<< HEAD
-    ) -> Self {
-=======
     ) -> ExtendedId {
->>>>>>> 142e514 (added ExtendedId conversions)
         let mut id = CanServiceId(0);
         id.set_priority(priority.to_u8().unwrap());
         id.set_svc(true);
@@ -120,11 +116,7 @@ impl CanServiceId {
         id.set_service_id(service_id);
         id.set_destination_id(destination);
         id.set_source_id(source);
-<<<<<<< HEAD
-        id
-=======
         ExtendedId::new(id.0).expect("not a extended CAN ID")
->>>>>>> 142e514 (added ExtendedId conversions)
     }
 
     pub fn valid(&self) -> bool {

--- a/uavcan/src/transport/can/bitfields.rs
+++ b/uavcan/src/transport/can/bitfields.rs
@@ -5,6 +5,7 @@
 //! are able to do some of the more basic checks that they are valid.
 
 use bitfield::bitfield;
+use embedded_hal::can::ExtendedId;
 use num_traits::ToPrimitive;
 
 use crate::types::*;
@@ -36,7 +37,7 @@ bitfield! {
 
 impl CanMessageId {
     // TODO bounds checks (can these be auto-implemented?)
-    pub fn new(priority: Priority, subject_id: PortId, source_id: Option<NodeId>) -> Self {
+    pub fn new(priority: Priority, subject_id: PortId, source_id: Option<NodeId>) -> ExtendedId {
         let is_anon = source_id.is_none();
         // TODO do better than XKCD 221
         let source_id = source_id.unwrap_or(4);
@@ -52,7 +53,7 @@ impl CanMessageId {
         id.set_rsvd2(true);
         id.set_rsvd3(false);
         // Return data
-        id
+        ExtendedId::new(id.0).expect("not a extended CAN ID")
     }
 
     /// Is this a message or a service ID?
@@ -70,6 +71,12 @@ impl CanMessageId {
         }
 
         true
+    }
+}
+
+impl From<ExtendedId> for CanMessageId {
+    fn from(id: ExtendedId) -> Self {
+        Self(id.as_raw())
     }
 }
 
@@ -100,7 +107,11 @@ impl CanServiceId {
         service_id: PortId,
         destination: NodeId,
         source: NodeId,
+<<<<<<< HEAD
     ) -> Self {
+=======
+    ) -> ExtendedId {
+>>>>>>> 142e514 (added ExtendedId conversions)
         let mut id = CanServiceId(0);
         id.set_priority(priority.to_u8().unwrap());
         id.set_svc(true);
@@ -109,7 +120,11 @@ impl CanServiceId {
         id.set_service_id(service_id);
         id.set_destination_id(destination);
         id.set_source_id(source);
+<<<<<<< HEAD
         id
+=======
+        ExtendedId::new(id.0).expect("not a extended CAN ID")
+>>>>>>> 142e514 (added ExtendedId conversions)
     }
 
     pub fn valid(&self) -> bool {
@@ -118,6 +133,12 @@ impl CanServiceId {
         }
 
         true
+    }
+}
+
+impl From<ExtendedId> for CanServiceId {
+    fn from(id: ExtendedId) -> Self {
+        Self(id.as_raw())
     }
 }
 

--- a/uavcan/src/transport/can/tests.rs
+++ b/uavcan/src/transport/can/tests.rs
@@ -32,7 +32,7 @@ fn receive_anon_frame() {
     let clock = TestClock::default();
     let mut frame = CanFrame {
         timestamp: clock.try_now().unwrap(),
-        id: CanMessageId::new(Priority::Nominal, 0, None).0,
+        id: CanMessageId::new(Priority::Nominal, 0, None),
         payload: ArrayVec::new(),
     };
 
@@ -52,7 +52,7 @@ fn receive_message_frame() {
     let clock = TestClock::default();
     let mut frame = CanFrame {
         timestamp: clock.try_now().unwrap(),
-        id: CanMessageId::new(Priority::Nominal, 0, Some(41)).0,
+        id: CanMessageId::new(Priority::Nominal, 0, Some(41)),
         payload: ArrayVec::new(),
     };
 
@@ -70,7 +70,7 @@ fn receive_service_frame() {
     let clock = TestClock::default();
     let mut frame = CanFrame {
         timestamp: clock.try_now().unwrap(),
-        id: CanServiceId::new(Priority::Nominal, false, 0, 42, 41).0,
+        id: CanServiceId::new(Priority::Nominal, false, 0, 42, 41),
         payload: ArrayVec::new(),
     };
 
@@ -81,7 +81,7 @@ fn receive_service_frame() {
     all_frame_asserts(internal_frame, Some(41), Some(42), true, true, &[224]);
 
     let mut frame = frame;
-    frame.id = CanServiceId::new(Priority::Nominal, true, 0, 42, 41).0;
+    frame.id = CanServiceId::new(Priority::Nominal, true, 0, 42, 41);
     let result = Can::rx_process_frame(&Some(42), &frame);
     let result = result.expect("Error processing service request frame");
     let internal_frame = result.expect("Failed to process valid service request frame");
@@ -111,7 +111,7 @@ fn discard_anon_multi_frame() {
     let clock = TestClock::default();
     let mut frame = CanFrame {
         timestamp: clock.try_now().unwrap(),
-        id: CanMessageId::new(Priority::Nominal, 0, None).0,
+        id: CanMessageId::new(Priority::Nominal, 0, None),
         payload: ArrayVec::new(),
     };
 
@@ -140,7 +140,7 @@ fn discard_misguided_service_frames() {
     let clock = TestClock::default();
     let mut frame = CanFrame {
         timestamp: clock.try_now().unwrap(),
-        id: CanServiceId::new(Priority::Nominal, true, 0, 31, 41).0,
+        id: CanServiceId::new(Priority::Nominal, true, 0, 31, 41),
         payload: ArrayVec::new(),
     };
 
@@ -162,7 +162,7 @@ fn discard_misguided_service_frames() {
     );
 
     // Response
-    frame.id = CanServiceId::new(Priority::Nominal, false, 0, 31, 41).0;
+    frame.id = CanServiceId::new(Priority::Nominal, false, 0, 31, 41);
     let result = Can::rx_process_frame(&Some(42), &frame);
     let result = result.unwrap();
     assert!(
@@ -185,7 +185,7 @@ fn tail_byte_checks() {
     // Start with invalid tail byte - toggle should be true to start transfer
     let mut frame = CanFrame {
         timestamp: clock.try_now().unwrap(),
-        id: CanMessageId::new(Priority::Nominal, 0, None).0,
+        id: CanMessageId::new(Priority::Nominal, 0, None),
         payload: ArrayVec::new(),
     };
 

--- a/uavcan/src/transport/can/tests.rs
+++ b/uavcan/src/transport/can/tests.rs
@@ -94,7 +94,7 @@ fn discard_empty_frame() {
     let clock = TestClock::default();
     let frame = CanFrame {
         timestamp: clock.try_now().unwrap(),
-        id: 0,
+        id: ExtendedId::ZERO,
         payload: ArrayVec::new(),
     };
     let result = Can::rx_process_frame(&Some(42), &frame);
@@ -234,7 +234,7 @@ fn transfer_valid_ids() {
         .unwrap()
         .next()
         .expect("Failed to create iter");
-    let id = CanMessageId(frame.id);
+    let id = CanMessageId::from(frame.id);
     assert!(id.is_message());
     assert!(id.is_anon());
     assert!(id.subject_id() == 0);
@@ -243,7 +243,7 @@ fn transfer_valid_ids() {
 
     let frame: CanFrame<TestClock<u32>> =
         CanIter::new(&transfer, Some(12)).unwrap().next().expect("");
-    let id = CanMessageId(frame.id);
+    let id = CanMessageId::from(frame.id);
     assert!(id.is_message());
     assert!(!id.is_anon());
     assert!(id.subject_id() == 0);


### PR DESCRIPTION
In the new release of [embedded-hal](https://github.com/rust-embedded/embedded-hal) (0.2.x), there exists standardized can ID structs. I would switch to them for better abstractions and better usage.