### PR TITLE
switch from generic duration to defined type

### DIFF
--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -13,7 +13,6 @@ embedded-time = "0.12.0"
 
 # TODO: if new embedded-hal version releases, this can be changed to crates.io
 embedded-hal = {version = "0.2.6", git = "https://github.com/rust-embedded/embedded-hal/", branch = "v0.2.x"}
-streaming-iterator = "0.1.5"
 
 [dependencies.uavcan]
 path = "../../uavcan"

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -1,5 +1,7 @@
+#![deny(warnings)]
+
 use embedded_hal::can::ExtendedId;
-use embedded_time::{duration::Milliseconds, Clock};
+use embedded_time::Clock;
 use uavcan::{
     session::StdVecSessionManager,
     time::StdClock,
@@ -14,7 +16,7 @@ use socketcan::{CANFrame, CANSocket};
 
 fn main() {
     let clock = StdClock::new();
-    let mut session_manager = StdVecSessionManager::<CanMetadata, Milliseconds, StdClock>::new();
+    let mut session_manager = StdVecSessionManager::<CanMetadata, StdClock>::new();
     session_manager
         .subscribe(Subscription::new(
             TransferKind::Message,
@@ -109,8 +111,10 @@ fn main() {
 
             let mut frame_iter = node.transmit(&transfer).unwrap();
             while let Some(frame) = frame_iter.next() {
-                sock.write_frame(&CANFrame::new(frame.id, &frame.payload, false, false).unwrap())
-                    .unwrap();
+                sock.write_frame(
+                    &CANFrame::new(frame.id.as_raw(), &frame.payload, false, false).unwrap(),
+                )
+                .unwrap();
 
                 //print!("Can frame {}: ", i);
                 //for byte in &frame.payload {

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -75,7 +75,7 @@ fn main() {
                         for byte in xfer.payload {
                             print!("0x{:02x} ", byte);
                         }
-                        println!("");
+                        println!();
                     }
                     TransferKind::Request => {
                         println!("Request Received!");

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -1,11 +1,13 @@
 use embedded_hal::can::ExtendedId;
-use embedded_time::duration::Milliseconds;
-use embedded_time::Clock;
-use streaming_iterator::StreamingIterator;
-use uavcan::session::StdVecSessionManager;
-use uavcan::time::StdClock;
-use uavcan::transport::can::{Can, CanFrame as UavcanFrame, CanMetadata};
-use uavcan::{transfer::Transfer, types::TransferId, Node, Priority, Subscription, TransferKind};
+use embedded_time::{duration::Milliseconds, Clock};
+use uavcan::{
+    session::StdVecSessionManager,
+    time::StdClock,
+    transfer::Transfer,
+    transport::can::{Can, CanFrame as UavcanFrame, CanMetadata},
+    types::TransferId,
+    Node, Priority, StreamingIterator, Subscription, TransferKind,
+};
 
 use arrayvec::ArrayVec;
 use socketcan::{CANFrame, CANSocket};

--- a/examples/embedded/Cargo.toml
+++ b/examples/embedded/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 
 [dependencies]
 
-cortex-m = "0.6.0"
-cortex-m-rt = "0.6.10"
+cortex-m = "0.7.1"
+cortex-m-rt = "0.7.1"
 stm32g4xx-hal = {version = "0.0.0", git = "https://github.com/stm32-rs/stm32g4xx-hal", features = ["rt", "stm32g431"] }
 
 alloc-cortex-m = "0.4.1"

--- a/examples/embedded/src/allocator.rs
+++ b/examples/embedded/src/allocator.rs
@@ -7,9 +7,11 @@ extern crate alloc;
 pub struct MyAllocator(Mutex<RefCell<Tlsf<'static, u8, u8, 8, 8>>>);
 
 impl MyAllocator {
-    pub const INIT: MyAllocator = MyAllocator(Mutex::new(RefCell::new(Tlsf::INIT)));
+    pub const fn init() -> Self {
+        Self(Mutex::new(RefCell::new(Tlsf::INIT)))
+    }
 
-    pub unsafe fn init(&self, pool: *mut u8, len: usize) -> usize {
+    pub unsafe fn set_pool(&self, pool: *mut u8, len: usize) -> usize {
         cortex_m::interrupt::free(|cs| {
             let mut tlsf = self.0.borrow(cs).borrow_mut();
 

--- a/examples/embedded/src/logging.rs
+++ b/examples/embedded/src/logging.rs
@@ -20,6 +20,7 @@ defmt::timestamp!("{=usize}", {
 });
 
 /// Terminates the application and makes `probe-run` exit with exit-code = 0
+#[allow(unused)]
 pub fn exit() -> ! {
     loop {
         cortex_m::asm::bkpt();

--- a/examples/embedded/src/main.rs
+++ b/examples/embedded/src/main.rs
@@ -16,7 +16,6 @@ mod allocator;
 mod clock;
 mod util;
 
-
 #[cfg(not(feature = "logging"))]
 use panic_halt as _;
 
@@ -124,7 +123,7 @@ fn main() -> ! {
     // init clock
     let clock = StmClock::new(dp.TIM7, &rcc.clocks);
 
-    let mut session_manager = HeapSessionManager::<CanMetadata, Milliseconds, StmClock>::new();
+    let mut session_manager = HeapSessionManager::<CanMetadata, StmClock>::new();
     session_manager
         .subscribe(Subscription::new(
             TransferKind::Message,
@@ -175,7 +174,7 @@ fn main() -> ! {
 }
 
 pub fn publish(
-    node: &mut Node<HeapSessionManager<CanMetadata, Milliseconds<u32>, StmClock>, Can, StmClock>,
+    node: &mut Node<HeapSessionManager<CanMetadata, StmClock>, Can, StmClock>,
     transfer: Transfer<StmClock>,
     can: &mut FdCan<FDCAN1, NormalOperationMode>,
 ) {

--- a/examples/embedded/src/main.rs
+++ b/examples/embedded/src/main.rs
@@ -55,14 +55,14 @@ use util::insert_u8_array_in_u32_array;
 static mut POOL: MaybeUninit<[u8; 1024]> = MaybeUninit::uninit();
 
 #[global_allocator]
-static ALLOCATOR: MyAllocator = MyAllocator::INIT;
+static ALLOCATOR: MyAllocator = MyAllocator::init();
 
 #[entry]
 fn main() -> ! {
     // init heap
     let cursor = unsafe { POOL.as_mut_ptr() } as *mut u8;
     let size = 1024;
-    unsafe { ALLOCATOR.init(cursor, size) };
+    unsafe { ALLOCATOR.set_pool(cursor, size) };
 
     // define peripherals of the board
     let dp = Peripherals::take().unwrap();
@@ -200,6 +200,7 @@ fn config_rcc(rcc: Rcc) -> Rcc {
     )
 }
 
+#[allow(clippy::empty_loop)]
 #[alloc_error_handler]
 fn oom(_: Layout) -> ! {
     loop {}

--- a/examples/embedded/src/main.rs
+++ b/examples/embedded/src/main.rs
@@ -1,5 +1,6 @@
 #![no_main]
 #![no_std]
+#![deny(warnings)]
 // to use the global allocator
 #![feature(alloc_error_handler)]
 
@@ -7,17 +8,10 @@
 #[macro_use]
 extern crate std;
 
-#[cfg(feature = "logging")]
-mod logging;
-#[cfg(feature = "logging")]
-use defmt::info;
-
 mod allocator;
 mod clock;
+mod logging;
 mod util;
-
-#[cfg(not(feature = "logging"))]
-use panic_halt as _;
 
 use core::{
     alloc::Layout,
@@ -28,10 +22,9 @@ use core::{
 use allocator::MyAllocator;
 use clock::StmClock;
 
-use cortex_m as _;
 use cortex_m_rt::entry;
 
-use embedded_time::{duration::Milliseconds, Clock};
+use embedded_time::Clock;
 use hal::{
     delay::SYSTDelayExt,
     fdcan::{
@@ -47,7 +40,6 @@ use hal::{
     prelude::*,
     rcc::{Config, PLLSrc, PllConfig, Rcc, RccExt, SysClockSrc},
     stm32::{Peripherals, FDCAN1},
-    timer::MonoTimer,
 };
 use stm32g4xx_hal as hal;
 
@@ -55,7 +47,7 @@ use uavcan::{
     session::HeapSessionManager,
     transfer::Transfer,
     transport::can::{Can, CanMetadata},
-    Node, Priority, Subscription, TransferKind,
+    Node, Priority, StreamingIterator, Subscription, TransferKind,
 };
 
 use util::insert_u8_array_in_u32_array;
@@ -118,8 +110,6 @@ fn main() -> ! {
         can.into_normal()
     };
 
-    let measure_clock = MonoTimer::new(cp.DWT, cp.DCB, &rcc.clocks);
-
     // init clock
     let clock = StmClock::new(dp.TIM7, &rcc.clocks);
 
@@ -178,11 +168,12 @@ pub fn publish(
     transfer: Transfer<StmClock>,
     can: &mut FdCan<FDCAN1, NormalOperationMode>,
 ) {
-    for frame in node.transmit(&transfer).unwrap() {
+    let mut iter = node.transmit(&transfer).unwrap();
+    while let Some(frame) = iter.next() {
         let header = TxFrameHeader {
             bit_rate_switching: false,
             frame_format: hal::fdcan::frame::FrameFormat::Standard,
-            id: Id::Extended(ExtendedId::new(frame.id).unwrap()),
+            id: Id::Extended(ExtendedId::new(frame.id.as_raw()).unwrap()),
             len: frame.payload.len() as u8,
             marker: None,
         };

--- a/examples/embedded/src/util.rs
+++ b/examples/embedded/src/util.rs
@@ -4,10 +4,10 @@
 pub fn insert_u8_array_in_u32_array(u8_array: &[u8], u32_array: &mut [u32]) {
     let u32_final_len = (u8_array.len() + 3) / 4;
     // only iterate over n - 1
-    for i in 0..u32_final_len - 1 {
-        let index = i * 4;
+    for (index, item) in u32_array.iter_mut().enumerate().take(u32_final_len - 1) {
+        let index = index * 4;
         let val = slice_into_u32(&u8_array[index..index + 4]);
-        u32_array[i] = val;
+        *item = val;
     }
     let remaining = match u8_array.len() % 4 {
         0 => 4,
@@ -25,16 +25,16 @@ pub fn insert_u8_array_in_u32_array(u8_array: &[u8], u32_array: &mut [u32]) {
 fn slice_into_u32(slice: &[u8]) -> u32 {
     // TODO nicer algorithm
     match slice.len() {
-        1 => return (slice[0] as u32) << 24,
-        2 => return (slice[0] as u32) << 24 | (slice[1] as u32) << 16,
-        3 => return (slice[0] as u32) << 24 | (slice[1] as u32) << 16 | (slice[2] as u32) << 8,
+        1 => (slice[0] as u32) << 24,
+        2 => (slice[0] as u32) << 24 | (slice[1] as u32) << 16,
+        3 => (slice[0] as u32) << 24 | (slice[1] as u32) << 16 | (slice[2] as u32) << 8,
         4 => {
-            return (slice[0] as u32) << 24
+            (slice[0] as u32) << 24
                 | (slice[1] as u32) << 16
                 | (slice[2] as u32) << 8
                 | (slice[3] as u32)
         }
-        _ => return 0,
+        _ => 0,
     }
 }
 

--- a/uavcan/src/crc16.rs
+++ b/uavcan/src/crc16.rs
@@ -53,7 +53,7 @@ impl Crc16 {
     /// Process the current crc sum further with the supplied data.
     pub fn digest<T: ?Sized + AsRef<[u8]>>(&mut self, data: &T) {
         for n in data.as_ref().iter().copied() {
-            let index = ((self.0 >> u16::from(Self::BITS - 8)) as u8 ^ n) as usize;
+            let index = ((self.0 >> (Self::BITS - 8)) as u8 ^ n) as usize;
             self.0 = (self.0 << 8) ^ NO_REF_16_1021[index];
         }
     }
@@ -62,15 +62,12 @@ impl Crc16 {
     pub fn get_crc(&self) -> u16 {
         let final_xor = 0x0000;
 
-        let sum = (self.0 ^ final_xor) & Crc16::mask();
-
-        sum
+        (self.0 ^ final_xor) & Crc16::mask()
     }
 
     const fn mask() -> u16 {
         let high_bit = 1 << (Self::BITS - 1);
-        let mask = ((high_bit - 1) << 1) | 1;
-        mask
+        ((high_bit - 1) << 1) | 1
     }
 }
 

--- a/uavcan/src/lib.rs
+++ b/uavcan/src/lib.rs
@@ -22,6 +22,7 @@
 //! this. I can see issues with this running into issues in multi-threaded
 //! environments, but I'll get to those when I get to them.
 #![no_std]
+#![deny(warnings)]
 #![feature(generic_associated_types)]
 #![feature(test)]
 

--- a/uavcan/src/lib.rs
+++ b/uavcan/src/lib.rs
@@ -45,8 +45,8 @@ pub mod transfer;
 pub mod transport;
 pub mod types;
 
-use embedded_time::fixed_point::FixedPoint;
 pub use node::Node;
+use time::Duration;
 pub use transfer::TransferKind;
 
 mod internal;
@@ -107,15 +107,20 @@ pub enum Priority {
 }
 
 /// Simple subscription type to
-pub struct Subscription<D: embedded_time::duration::Duration + FixedPoint> {
+pub struct Subscription {
     transfer_kind: TransferKind,
     port_id: PortId,
     extent: usize,
-    timeout: D,
+    timeout: Duration,
 }
 
-impl<D: embedded_time::duration::Duration + FixedPoint> Subscription<D> {
-    pub fn new(transfer_kind: TransferKind, port_id: PortId, extent: usize, timeout: D) -> Self {
+impl Subscription {
+    pub fn new(
+        transfer_kind: TransferKind,
+        port_id: PortId,
+        extent: usize,
+        timeout: Duration,
+    ) -> Self {
         Self {
             transfer_kind,
             port_id,
@@ -125,8 +130,8 @@ impl<D: embedded_time::duration::Duration + FixedPoint> Subscription<D> {
     }
 }
 
-impl<D: embedded_time::duration::Duration + FixedPoint> PartialEq for Subscription<D> {
+impl PartialEq for Subscription {
     fn eq(&self, other: &Self) -> bool {
-        self.transfer_kind == other.transfer_kind && self.port_id == other.port_id
+        return self.transfer_kind == other.transfer_kind && self.port_id == other.port_id;
     }
 }

--- a/uavcan/src/lib.rs
+++ b/uavcan/src/lib.rs
@@ -49,6 +49,8 @@ pub use node::Node;
 use time::Duration;
 pub use transfer::TransferKind;
 
+pub use streaming_iterator::StreamingIterator;
+
 mod internal;
 mod node;
 pub mod session;

--- a/uavcan/src/lib.rs
+++ b/uavcan/src/lib.rs
@@ -135,6 +135,6 @@ impl Subscription {
 
 impl PartialEq for Subscription {
     fn eq(&self, other: &Self) -> bool {
-        return self.transfer_kind == other.transfer_kind && self.port_id == other.port_id;
+        self.transfer_kind == other.transfer_kind && self.port_id == other.port_id
     }
 }

--- a/uavcan/src/session/heap_based.rs
+++ b/uavcan/src/session/heap_based.rs
@@ -217,6 +217,18 @@ where
     }
 }
 
+impl<T, C> Default for HeapSessionManager<T, C>
+where
+    T: crate::transport::SessionMetadata<C>,
+    C: Clock,
+{
+    fn default() -> Self {
+        Self {
+            subscriptions: Default::default(),
+        }
+    }
+}
+
 impl<T, C> SessionManager<C> for HeapSessionManager<T, C>
 where
     T: crate::transport::SessionMetadata<C>,

--- a/uavcan/src/session/mod.rs
+++ b/uavcan/src/session/mod.rs
@@ -64,10 +64,7 @@ pub trait SessionManager<C: embedded_time::Clock> {
     ///
     /// It's not necessary to use this in your implementation, you may have
     /// a more efficient way to check, but this is a spec-compliant function.
-    fn matches_sub<D: embedded_time::duration::Duration + FixedPoint>(
-        subscription: &crate::Subscription<D>,
-        frame: &InternalRxFrame<C>,
-    ) -> bool {
+    fn matches_sub(subscription: &crate::Subscription, frame: &InternalRxFrame<C>) -> bool {
         // Order is chosen to short circuit the most common inconsistencies.
         if frame.port_id != subscription.port_id {
             return false;
@@ -76,7 +73,7 @@ pub trait SessionManager<C: embedded_time::Clock> {
             return false;
         }
 
-        true
+        return true;
     }
 }
 
@@ -95,5 +92,5 @@ where
         }
     }
 
-    false
+    return false;
 }

--- a/uavcan/src/session/mod.rs
+++ b/uavcan/src/session/mod.rs
@@ -73,7 +73,7 @@ pub trait SessionManager<C: embedded_time::Clock> {
             return false;
         }
 
-        return true;
+        true
     }
 }
 
@@ -92,5 +92,5 @@ where
         }
     }
 
-    return false;
+    false
 }

--- a/uavcan/src/time.rs
+++ b/uavcan/src/time.rs
@@ -1,4 +1,5 @@
 pub type Timestamp<C> = embedded_time::Instant<C>;
+pub type Duration = embedded_time::duration::Milliseconds;
 
 #[cfg(test)]
 pub use test_clock::TestClock;
@@ -180,12 +181,6 @@ mod std_clock {
         /// The clock is zeroed at this time point.  
         pub fn new() -> Self {
             Self(Rc::new(RefCell::new(Instant::now())))
-        }
-    }
-
-    impl Default for StdClock {
-        fn default() -> Self {
-            Self::new()
         }
     }
 

--- a/uavcan/src/time.rs
+++ b/uavcan/src/time.rs
@@ -184,6 +184,12 @@ mod std_clock {
         }
     }
 
+    impl Default for StdClock {
+        fn default() -> Self {
+            Self(Rc::new(RefCell::new(Instant::now())))
+        }
+    }
+
     impl embedded_time::Clock for StdClock {
         type T = u64;
 

--- a/uavcan/src/transport/can/bitfields.rs
+++ b/uavcan/src/transport/can/bitfields.rs
@@ -37,6 +37,7 @@ bitfield! {
 
 impl CanMessageId {
     // TODO bounds checks (can these be auto-implemented?)
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(priority: Priority, subject_id: PortId, source_id: Option<NodeId>) -> ExtendedId {
         let is_anon = source_id.is_none();
         // TODO do better than XKCD 221
@@ -101,6 +102,7 @@ bitfield! {
 }
 
 impl CanServiceId {
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         priority: Priority,
         is_request: bool,

--- a/uavcan/src/transport/can/mod.rs
+++ b/uavcan/src/transport/can/mod.rs
@@ -247,16 +247,16 @@ impl<'a, C: Clock> StreamingIterator for CanIter<'a, C> {
             self.payload_offset += bytes_left;
             self.crc_left = 0;
             unsafe {
-                frame.payload.push_unchecked(
-                    TailByte::new(true, true, true, self.transfer.transfer_id).0
-                )
+                frame
+                    .payload
+                    .push_unchecked(TailByte::new(true, true, true, self.transfer.transfer_id).0)
             }
         } else {
             // Handle CRC
             let out_data =
                 &self.transfer.payload[self.payload_offset..self.payload_offset + copy_len];
             self.crc.digest(out_data);
-            frame.payload.extend(out_data.into_iter().copied());
+            frame.payload.extend(out_data.iter().copied());
 
             // Increment offset
             self.payload_offset += copy_len;
@@ -291,12 +291,15 @@ impl<'a, C: Clock> StreamingIterator for CanIter<'a, C> {
 
             // SAFETY: should only copy at most 7 elements prior to here
             unsafe {
-                frame.payload.push_unchecked(TailByte::new(
-                    self.is_start,
-                    is_end,
-                    self.toggle,
-                    self.transfer.transfer_id,
-                ).0);
+                frame.payload.push_unchecked(
+                    TailByte::new(
+                        self.is_start,
+                        is_end,
+                        self.toggle,
+                        self.transfer.transfer_id,
+                    )
+                    .0,
+                );
             }
 
             // Advance state of iter


### PR DESCRIPTION
To reduce the generic types from structs in session, I switched to a defined type defined in `time.rs`.